### PR TITLE
[codex] Preserve ubus session cookies in setup

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -34,6 +34,7 @@ REMOTE_BIN=/data/zte-agent
 STARTUP_SCRIPT=/data/local/tmp/start_zte_agent.sh
 BINARY_CHANGED=false
 DOWNLOAD_URL="https://github.com/jesther-ai/open-u60-pro/releases/latest/download/zte-agent"
+COOKIE_JAR="$(mktemp -t open-u60-pro-cookies.XXXXXX)"
 
 # ── Binary source menu ──────────────────────────────────────────────
 echo ""
@@ -225,6 +226,10 @@ ubus_call() {
     ts=$(date +%s)
     curl -sf "http://$GATEWAY/ubus/?t=$ts" \
         -H 'Content-Type: application/json' \
+        -H "Origin: http://$GATEWAY" \
+        -H "Referer: http://$GATEWAY/" \
+        -b "$COOKIE_JAR" \
+        -c "$COOKIE_JAR" \
         -d "[{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"call\",\"params\":[\"$session\",\"$object\",\"$method\",$params]}]"
 }
 

--- a/setup.sh
+++ b/setup.sh
@@ -35,6 +35,7 @@ STARTUP_SCRIPT=/data/local/tmp/start_zte_agent.sh
 BINARY_CHANGED=false
 DOWNLOAD_URL="https://github.com/jesther-ai/open-u60-pro/releases/latest/download/zte-agent"
 COOKIE_JAR="$(mktemp -t open-u60-pro-cookies.XXXXXX)"
+trap 'rm -f "$COOKIE_JAR"' EXIT
 
 # ── Binary source menu ──────────────────────────────────────────────
 echo ""


### PR DESCRIPTION
## Summary

- Preserve router web-session cookies across `setup.sh` ubus JSON-RPC calls.
- Send matching `Origin` and `Referer` headers when calling `/ubus/`.
- Clean up the temporary cookie jar on script exit.

## Why

Some router firmware expects ubus calls to keep the same browser-like session context after login. Without a cookie jar and origin/referrer headers, later calls can fail even when the password flow is otherwise correct.

## Validation

- `bash -n setup.sh`
- End-to-end tested on a U60 Pro HK firmware BO3 build: web login returned `ubus_rpc_session`, then the follow-up ubus call succeeded using the same cookie jar/session context.
