### PR TITLE
Add Tailscale remote management to the iOS and Android apps

### DIFF
--- a/mobile/android/OpenU60/app/src/main/java/com/openu60/core/model/TailscaleModels.kt
+++ b/mobile/android/OpenU60/app/src/main/java/com/openu60/core/model/TailscaleModels.kt
@@ -1,0 +1,182 @@
+package com.openu60.core.model
+
+import java.time.Instant
+import java.time.OffsetDateTime
+
+// MARK: - Tailscale
+
+/** A release resolved from pkgs.tailscale.com. The agent verifies the download against [sha256]. */
+data class TailscaleRelease(
+    val version: String,
+    val sha256: String,
+)
+
+data class TailscaleLastUpdate(
+    val version: String = "",
+    val ok: Boolean = false,
+    val error: String? = null,
+    val finishedAt: Long = 0L,
+)
+
+data class TailscaleStatus(
+    val installed: Boolean = false,
+    val enabled: Boolean = false,
+    val enrolled: Boolean = false,
+    val daemonRunning: Boolean = false,
+    val state: String = "unknown",
+    val backendState: String? = null,
+    val health: List<String> = emptyList(),
+    val tailscaleIps: List<String> = emptyList(),
+    val dnsName: String? = null,
+    val relay: String? = null,
+    val direct: Boolean = false,
+    val keyExpiry: String? = null,
+    val expired: Boolean = false,
+    val clientVersion: String? = null,
+    val loginUrl: String? = null,
+    val wakelockHeld: Boolean = false,
+    val updating: Boolean = false,
+    val lastUpdate: TailscaleLastUpdate? = null,
+    val hostname: String = "u60-pro",
+    val advertiseRoutes: List<String> = emptyList(),
+    val tailscaleSsh: Boolean = false,
+    val holdWakelock: Boolean = true,
+    val pinnedVersion: String = "",
+    val error: String? = null,
+) {
+    companion object {
+        val empty = TailscaleStatus()
+    }
+
+    val displayDnsName: String? get() = dnsName?.takeIf { it.isNotEmpty() }?.removeSuffix(".")
+
+    val primaryIp: String? get() = tailscaleIps.firstOrNull()
+
+    /** Relayed is expected behind CGNAT-to-CGNAT, so this reads neutrally rather than as a fault. */
+    val pathDescription: String get() = when {
+        direct -> "Direct"
+        !relay.isNullOrEmpty() -> "Via relay ($relay)"
+        else -> "Via relay"
+    }
+
+    /** hold_wakelock is intent; wakelock_held is whether the router actually granted it. */
+    val wakelockFailing: Boolean get() = enabled && holdWakelock && !wakelockHeld
+
+    /** A version swap that did not take effect. */
+    val versionMismatch: Boolean get() =
+        pinnedVersion.isNotEmpty() && !clientVersion.isNullOrEmpty() && pinnedVersion != clientVersion
+
+    /**
+     * Parsed key_expiry. Null when expiry is disabled — which is the GOOD outcome and must
+     * render as "Never", not as unknown — and also when the string won't parse, so callers
+     * that distinguish the two must test [keyExpiry] itself.
+     */
+    val keyExpiryAt: Instant? get() = keyExpiry?.let {
+        runCatching { OffsetDateTime.parse(it).toInstant() }.getOrNull()
+    }
+}
+
+object TailscaleParser {
+
+    /**
+     * REQUIRED — see AgentClient.toAny(): it coerces a JSON *string* through
+     * booleanOrNull ?: intOrNull ?: longOrNull ?: doubleOrNull before falling back to
+     * content, and none of those check isString. The string "12345" therefore arrives as
+     * Int and "1.98" as Double, so `as? String` yields null for an all-digit hostname
+     * (which the agent accepts) or a two-component version. DeviceParser has no asString.
+     *
+     * Public because the same hazard applies to every Tailscale payload, not just /status.
+     */
+    fun asString(value: Any?): String? = when (value) {
+        null -> null
+        is String -> value
+        else -> value.toString()
+    }
+
+    private fun asStringList(value: Any?): List<String> =
+        (value as? List<*>)?.mapNotNull { asString(it) } ?: emptyList()
+
+    fun parse(data: Map<String, Any?>): TailscaleStatus = TailscaleStatus(
+        installed = DeviceParser.asBool(data["installed"]),
+        enabled = DeviceParser.asBool(data["enabled"]),
+        enrolled = DeviceParser.asBool(data["enrolled"]),
+        daemonRunning = DeviceParser.asBool(data["daemon_running"]),
+        state = asString(data["state"]) ?: "unknown",
+        backendState = asString(data["backend_state"]),
+        health = asStringList(data["health"]),
+        // tailscale_ips can be NULL, not just [], when unenrolled — this collapses both.
+        tailscaleIps = asStringList(data["tailscale_ips"]),
+        dnsName = asString(data["dns_name"]),
+        relay = asString(data["relay"]),
+        direct = DeviceParser.asBool(data["direct"]),
+        keyExpiry = asString(data["key_expiry"]),
+        expired = DeviceParser.asBool(data["expired"]),
+        clientVersion = asString(data["client_version"]),
+        loginUrl = asString(data["login_url"]),
+        wakelockHeld = DeviceParser.asBool(data["wakelock_held"]),
+        updating = DeviceParser.asBool(data["updating"]),
+        lastUpdate = parseLastUpdate(data["last_update"] as? Map<*, *>),
+        hostname = asString(data["hostname"]) ?: "u60-pro",
+        advertiseRoutes = asStringList(data["advertise_routes"]),
+        tailscaleSsh = DeviceParser.asBool(data["tailscale_ssh"]),
+        // The agent's serde default is TRUE — an absent key must not become false.
+        holdWakelock = if (data.containsKey("hold_wakelock")) DeviceParser.asBool(data["hold_wakelock"]) else true,
+        pinnedVersion = asString(data["pinned_version"]) ?: "",
+        // The only field whose key is absent unless state == "starting".
+        error = asString(data["error"]),
+    )
+
+    private fun parseLastUpdate(d: Map<*, *>?): TailscaleLastUpdate? {
+        if (d == null) return null
+        return TailscaleLastUpdate(
+            version = asString(d["version"]) ?: "",
+            ok = DeviceParser.asBool(d["ok"]),
+            error = asString(d["error"]),
+            finishedAt = DeviceParser.asLong(d["finished_at"]) ?: 0L,
+        )
+    }
+}
+
+/**
+ * Mirrors the agent's own validation so a bad value never becomes a 400 the user has to
+ * decode. Every rule below is deliberately ASCII-only: Kotlin's Char.isDigit() and
+ * isLetterOrDigit() are Unicode-aware and would accept input the Rust side rejects.
+ */
+object TailscaleValidator {
+
+    fun hostname(value: String): String? {
+        val v = value.trim()
+        return if (v.isNotEmpty() && v.length <= 63 && v.all { it.isAsciiAlnum() || it == '-' }) null
+        else "Use 1-63 letters, numbers or hyphens."
+    }
+
+    /** Comma-separated field to the array the agent wants. Empty means "clear all routes". */
+    fun parseRoutes(value: String): List<String> =
+        value.split(',').map { it.trim() }.filter { it.isNotEmpty() }
+
+    fun routes(value: String): String? =
+        if (parseRoutes(value).all { validCidr(it) }) null
+        else "Only IPv4 routes like 192.168.0.0/24 are supported."
+
+    fun version(value: String): String? =
+        if (value.isNotEmpty() && value.all { it.isAsciiDigit() || it == '.' }) null
+        else "Use digits and dots only, like 1.98.9."
+
+    fun sha256(value: String): String? =
+        if (value.length == 64 && value.all { it.isAsciiHex() }) null
+        else "Must be exactly 64 hexadecimal characters."
+
+    /** IPv4-only, and host bits are not checked — exactly matching the agent's valid_cidr. */
+    private fun validCidr(value: String): Boolean {
+        val parts = value.split('/', limit = 2)
+        if (parts.size != 2) return false
+        val octets = parts[0].split('.')
+        val addrOk = octets.size == 4 && octets.all { o -> o.toIntOrNull()?.let { it in 0..255 } == true }
+        val prefixOk = parts[1].toIntOrNull()?.let { it in 0..32 } == true
+        return addrOk && prefixOk
+    }
+
+    private fun Char.isAsciiAlnum(): Boolean = this in '0'..'9' || this in 'a'..'z' || this in 'A'..'Z'
+    private fun Char.isAsciiDigit(): Boolean = this in '0'..'9'
+    private fun Char.isAsciiHex(): Boolean = this in '0'..'9' || this in 'a'..'f' || this in 'A'..'F'
+}

--- a/mobile/android/OpenU60/app/src/main/java/com/openu60/core/network/AgentClient.kt
+++ b/mobile/android/OpenU60/app/src/main/java/com/openu60/core/network/AgentClient.kt
@@ -32,6 +32,15 @@ class AgentClient @Inject constructor() {
         .readTimeout(3, TimeUnit.SECONDS)
         .build()
 
+    // For the handful of endpoints that legitimately block for minutes (tailscale
+    // setup/login-url/logout/disable/config). Separate from httpClient so raising the cap
+    // can't weaken the 15s read timeout every other screen depends on; newBuilder() shares
+    // the connection pool and dispatcher.
+    private val slowClient = httpClient.newBuilder()
+        .readTimeout(240, TimeUnit.SECONDS)
+        .writeTimeout(30, TimeUnit.SECONDS)
+        .build()
+
     var baseURL: String = "http://192.168.0.1:9090"
     var token: String? = null
 
@@ -90,6 +99,18 @@ class AgentClient @Inject constructor() {
         return unwrapResponse(data)
     }
 
+    suspend fun postJSONSlow(path: String, body: Map<String, Any?> = emptyMap()): Map<String, Any?> {
+        val bodyStr = mapToJsonString(body)
+        val data = request("POST", path, bodyStr, slow = true)
+        return unwrapResponse(data)
+    }
+
+    suspend fun putJSONSlow(path: String, body: Map<String, Any?> = emptyMap()): Map<String, Any?> {
+        val bodyStr = mapToJsonString(body)
+        val data = request("PUT", path, bodyStr, slow = true)
+        return unwrapResponse(data)
+    }
+
     // MARK: - Auth
 
     suspend fun login(password: String): String {
@@ -128,6 +149,7 @@ class AgentClient @Inject constructor() {
         path: String,
         body: String?,
         authenticated: Boolean = true,
+        slow: Boolean = false,
     ): String = withContext(Dispatchers.IO) {
         val url = baseURL + path
 
@@ -151,13 +173,14 @@ class AgentClient @Inject constructor() {
         }
 
         try {
-            val response = httpClient.newCall(builder.build()).execute()
+            val client = if (slow) slowClient else httpClient
+            val response = client.newCall(builder.build()).execute()
             val responseBody = response.body?.string() ?: ""
 
             when (response.code) {
                 in 200..299 -> responseBody
                 401 -> throw AgentError.Unauthorized()
-                else -> throw AgentError.ServerError(responseBody.ifEmpty { "HTTP ${response.code}" })
+                else -> throw parseApiError(response.code, responseBody)
             }
         } catch (e: AgentError) {
             throw e
@@ -168,6 +191,16 @@ class AgentClient @Inject constructor() {
         } catch (e: Exception) {
             throw AgentError.NetworkError(e.message ?: "Unknown", e)
         }
+    }
+
+    /** Lifts the envelope's `error` so callers get a clean message and the status code. */
+    private fun parseApiError(code: Int, body: String): AgentError {
+        val msg = try {
+            Json.parseToJsonElement(body).jsonObject["error"]?.jsonPrimitive?.contentOrNull
+        } catch (_: Exception) {
+            null
+        }
+        return AgentError.ApiError(code, msg?.ifEmpty { null } ?: body.ifEmpty { "HTTP $code" })
     }
 
     @PublishedApi

--- a/mobile/android/OpenU60/app/src/main/java/com/openu60/core/network/AgentError.kt
+++ b/mobile/android/OpenU60/app/src/main/java/com/openu60/core/network/AgentError.kt
@@ -2,6 +2,12 @@ package com.openu60.core.network
 
 sealed class AgentError(override val message: String, override val cause: Throwable? = null) : Exception(message, cause) {
     class Unauthorized : AgentError("Not authenticated. Please log in.")
+
+    /**
+     * A non-2xx response whose HTTP status the caller has to branch on. Carries the agent's
+     * own `error` string unprefixed — those are already human-readable and get shown verbatim.
+     */
+    class ApiError(val status: Int, val serverMessage: String) : AgentError(serverMessage)
     class ServerError(msg: String) : AgentError("Server error: $msg")
     class NetworkError(msg: String, cause: Throwable? = null) : AgentError("Network error: $msg", cause)
     class DecodingError(msg: String) : AgentError("Failed to decode response: $msg")

--- a/mobile/android/OpenU60/app/src/main/java/com/openu60/feature/router/RouterSettingsListScreen.kt
+++ b/mobile/android/OpenU60/app/src/main/java/com/openu60/feature/router/RouterSettingsListScreen.kt
@@ -32,6 +32,7 @@ fun RouterSettingsListScreen(
     onNavigateToFirewall: () -> Unit,
     onNavigateToTelemetryBlocker: () -> Unit,
     onNavigateToVPNPassthrough: () -> Unit,
+    onNavigateToTailscale: () -> Unit,
     onNavigateToQoS: () -> Unit,
     onNavigateToDeviceControl: () -> Unit,
     onNavigateToScheduleReboot: () -> Unit,
@@ -76,6 +77,7 @@ fun RouterSettingsListScreen(
             SettingsItem(Icons.Default.Shield, "Firewall", onClick = onNavigateToFirewall)
             SettingsItem(Icons.Default.VisibilityOff, "Telemetry Blocker", onClick = onNavigateToTelemetryBlocker)
             SettingsItem(Icons.Default.VpnKey, "VPN Passthrough", onClick = onNavigateToVPNPassthrough)
+            SettingsItem(Icons.Default.Cloud, "Tailscale", onClick = onNavigateToTailscale)
 
             Spacer(modifier = Modifier.height(8.dp))
 

--- a/mobile/android/OpenU60/app/src/main/java/com/openu60/feature/router/tailscale/TailscaleScreen.kt
+++ b/mobile/android/OpenU60/app/src/main/java/com/openu60/feature/router/tailscale/TailscaleScreen.kt
@@ -1,0 +1,1000 @@
+package com.openu60.feature.router.tailscale
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.*
+import androidx.compose.material3.*
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.platform.UriHandler
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.openu60.core.model.TailscaleRelease
+import com.openu60.core.model.TailscaleStatus
+import com.openu60.core.model.TailscaleValidator
+import java.text.SimpleDateFormat
+import java.time.Duration
+import java.time.Instant
+import java.util.Date
+import java.util.Locale
+
+private const val URL_ADMIN_MACHINES = "https://login.tailscale.com/admin/machines"
+private const val URL_KEYS = "https://login.tailscale.com/admin/settings/keys"
+
+private const val COPY_ADMIN_LINK = "Open Admin Console"
+
+private const val COPY_GATE_TITLE = "Remote access needs an agent password"
+private const val COPY_GATE_BODY =
+    "This router's agent has no password, so its API is open to anyone who can reach it. Turning on " +
+        "Tailscale would expose the router's full management API to every device on your tailnet — over " +
+        "the tunnel every request arrives from 127.0.0.1 with no peer identity, so the agent can't tell " +
+        "your laptop from anyone else's.\n\nSet ZTE_AGENT_PASSWORD on the router and restart the agent, " +
+        "then come back."
+
+private const val COPY_LOGOUT_WARNING_PREFIX = "Logged out, but this router's key was NOT invalidated:"
+private const val COPY_LOGOUT_WARNING_SUFFIX =
+    "It may still be a live machine on your tailnet. Remove it in the admin console."
+private const val COPY_LOGOUT_WARNING_ACK = "I've removed it"
+
+private const val COPY_WAKELOCK_ALERT_TITLE = "The router may go to sleep"
+private const val COPY_WAKELOCK_ALERT_BODY =
+    "\"Keep router awake\" is on, but the router refused the wakelock. It may sleep and become " +
+        "unreachable even though it looks connected."
+
+private const val COPY_EXPIRED_TITLE = "Node key expired"
+private const val COPY_EXPIRED_BODY = "Remote access is down until you sign in again."
+
+private const val COPY_EXPIRING_BODY =
+    "When it expires, remote access stops and can only be restored from the local network. Disable key " +
+        "expiry for this machine in your Tailscale admin console."
+
+private const val COPY_REMOTE_BANNER_TITLE = "You're managing this router over Tailscale"
+private const val COPY_REMOTE_BANNER_BODY = "Turning off, logging out, or updating will drop this connection."
+
+private const val COPY_REMOTE_SESSION_PARAGRAPH =
+    "You're connected to this router over Tailscale right now. This will drop your connection " +
+        "immediately, and you won't be able to reconnect remotely. Continue only if you have local " +
+        "network or physical access to the router."
+
+private const val COPY_NEEDS_LOGIN_FOOTER =
+    "If this router re-registers as a new machine, delete the old entry in your Tailscale admin console."
+private const val COPY_HEALTHY_TURN_OFF_FOOTER = "If you're connected over Tailscale, this will end that connection."
+
+private const val COPY_ADVISORIES_FOOTER =
+    "These are reported by Tailscale and are often benign. They don't affect whether the router is reachable."
+private const val COPY_SETTINGS_FOOTER = "This router doesn't accept DNS or subnet routes from your tailnet."
+private const val COPY_WAKELOCK_FOOTER =
+    "Keeps the router awake so it stays reachable. Turning this off lets the router sleep, and it will " +
+        "become unreachable even though it looks connected."
+private const val COPY_MAINTENANCE_FOOTER =
+    "Update from Wi-Fi on the same network as the router. Updating restarts Tailscale and will drop a " +
+        "remote connection."
+private const val COPY_DANGER_FOOTER = "Turning off keeps this router's sign-in. Logging out deletes it."
+
+private const val COPY_ENROLL_TITLE = "Set Up Remote Access"
+private const val COPY_ENROLL_INTRO = "Connect this router to your tailnet so you can reach it from anywhere."
+private const val COPY_ENROLL_AUTHKEY_TAB = "Auth key (recommended)"
+private const val COPY_ENROLL_BROWSER_TAB = "Browser sign-in"
+private const val COPY_ENROLL_AUTHKEY_GUIDANCE =
+    "Create a one-off, pre-authorized key tagged tag:router in the Tailscale admin console. Tagging is " +
+        "what stops the key from expiring — an untagged router stops working after about 180 days and " +
+        "can only be fixed from the local network."
+private const val COPY_ENROLL_KEYS_LINK = "Open Tailscale Keys Page"
+private const val COPY_ENROLL_BROWSER_GUIDANCE =
+    "This router is added under your account, and its key will expire (default 180 days) unless you " +
+        "disable key expiry for it in the admin console."
+
+private const val COPY_DISABLE_TITLE = "Turn off remote access?"
+private const val COPY_DISABLE_BODY =
+    "The router disconnects from your tailnet. Its sign-in is kept, so you can turn it back on later — " +
+        "but only from the local network if you lose remote access."
+
+private const val COPY_LOGOUT_TITLE = "Log out of Tailscale?"
+private const val COPY_LOGOUT_BODY =
+    "This permanently deletes this router's Tailscale identity.\n\n• Remote access stops immediately.\n" +
+        "• Reconnecting requires a new auth key or browser sign-in.\n• This can't be undone."
+
+private const val COPY_SSH_CONFIRM_BODY =
+    "Devices on your tailnet that your ACLs permit will be able to open a shell on this router. Access " +
+        "is governed by your tailnet ACLs, which this app can't show you."
+private const val COPY_ROUTE_CONFIRM_BODY =
+    "This exposes that entire subnet — every device on your LAN — to your tailnet. Subnet routes must " +
+        "also be approved in the Tailscale admin console before they carry traffic."
+private const val COPY_SLEEP_CONFIRM_BODY =
+    "Without the wakelock the router's CPU sleeps and the node becomes unreachable, even though it will " +
+        "still look connected. Remote access will be unreliable."
+
+private const val COPY_RELEASE_FETCHING = "Checking for the latest Tailscale release…"
+private const val COPY_RELEASE_SOURCE =
+    "Version and checksum come from pkgs.tailscale.com. The router verifies the download against this " +
+        "checksum before installing."
+private const val COPY_UPDATE_DATA_WARNING =
+    "The router downloads this over its own connection. If the router is on mobile data, this uses about " +
+        "34 MB of your data plan."
+private const val COPY_UPDATE_REMOTE_WARNING =
+    "You're connected over Tailscale. Updating restarts the daemon and will drop this connection and any " +
+        "Tailscale SSH sessions. Do this from the local network."
+private const val COPY_UPDATE_UNENROLLED_WARNING =
+    "This router isn't enrolled, so the automatic rollback watchdog won't run for this update."
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun TailscaleScreen(
+    onBack: () -> Unit,
+    viewModel: TailscaleViewModel = hiltViewModel(),
+) {
+    val state by viewModel.state.collectAsState()
+    val clipboard = LocalClipboardManager.current
+    val uriHandler = LocalUriHandler.current
+
+    LaunchedEffect(Unit) { viewModel.refresh() }
+
+    val copy: (String) -> Unit = { value ->
+        clipboard.setText(AnnotatedString(value))
+        viewModel.noteCopiedToClipboard()
+    }
+
+    if (state.showEnrollSheet) {
+        EnrollDialog(
+            connectEnabled = state.op == TailscaleOp.NONE,
+            onOpenKeysPage = { uriHandler.openUri(URL_KEYS) },
+            onDismiss = { viewModel.dismissEnrollSheet() },
+            onAuthKey = { viewModel.setup(it) },
+            onBrowserLogin = { viewModel.startBrowserLogin() },
+        )
+    }
+
+    if (state.showUpdateSheet) {
+        UpdateDialog(
+            isInstall = !state.status.installed,
+            fetching = state.releaseFetching,
+            release = state.release,
+            releaseError = state.releaseError,
+            remoteSession = state.isRemoteSession,
+            enrolled = state.status.enrolled,
+            onRetry = { viewModel.fetchLatestRelease() },
+            onDismiss = { viewModel.dismissUpdateSheet() },
+            onConfirm = { version, sha -> viewModel.update(version, sha) },
+        )
+    }
+
+    if (state.showDisableConfirm) {
+        ConfirmDialog(
+            title = COPY_DISABLE_TITLE,
+            message = withRemoteSession(COPY_DISABLE_BODY, state.isRemoteSession),
+            confirmLabel = "Turn Off",
+            onDismiss = { viewModel.dismissDisableConfirm() },
+            onConfirm = { viewModel.disable() },
+        )
+    }
+
+    if (state.showLogoutConfirm) {
+        val message = withRemoteSession(COPY_LOGOUT_BODY, state.isRemoteSession)
+        if (state.hasSavedPassword) {
+            PasswordConfirmDialog(
+                title = COPY_LOGOUT_TITLE,
+                message = message,
+                confirmLabel = "Log Out",
+                verify = viewModel::verifyPassword,
+                onDismiss = { viewModel.dismissLogoutConfirm() },
+                onConfirm = { viewModel.logout() },
+            )
+        } else {
+            ConfirmDialog(
+                title = COPY_LOGOUT_TITLE,
+                message = message,
+                confirmLabel = "Log Out",
+                onDismiss = { viewModel.dismissLogoutConfirm() },
+                onConfirm = { viewModel.logout() },
+            )
+        }
+    }
+
+    state.configConfirms.firstOrNull()?.let { confirm ->
+        ConfirmDialog(
+            title = when (confirm) {
+                is TailscaleConfigConfirm.AllowSsh -> "Allow Tailscale SSH?"
+                is TailscaleConfigConfirm.AdvertiseRoute -> "Advertise ${confirm.cidr}?"
+                is TailscaleConfigConfirm.AllowSleep -> "Let the router sleep?"
+            },
+            message = when (confirm) {
+                is TailscaleConfigConfirm.AllowSsh -> COPY_SSH_CONFIRM_BODY
+                is TailscaleConfigConfirm.AdvertiseRoute -> COPY_ROUTE_CONFIRM_BODY
+                is TailscaleConfigConfirm.AllowSleep -> COPY_SLEEP_CONFIRM_BODY
+            },
+            confirmLabel = when (confirm) {
+                is TailscaleConfigConfirm.AllowSsh -> "Allow SSH"
+                is TailscaleConfigConfirm.AdvertiseRoute -> "Advertise"
+                is TailscaleConfigConfirm.AllowSleep -> "Allow Sleep"
+            },
+            onDismiss = { viewModel.dismissConfigConfirms() },
+            onConfirm = { viewModel.acceptConfigConfirm() },
+        )
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Tailscale") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        PullToRefreshBox(
+            isRefreshing = state.isLoading,
+            onRefresh = { viewModel.refresh() },
+            modifier = Modifier.fillMaxSize().padding(padding),
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .verticalScroll(rememberScrollState())
+                    .padding(16.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                state.message?.let { msg ->
+                    Card(
+                        colors = CardDefaults.cardColors(
+                            containerColor = if (state.messageIsError) MaterialTheme.colorScheme.errorContainer
+                            else MaterialTheme.colorScheme.primaryContainer,
+                        ),
+                    ) {
+                        Text(
+                            msg,
+                            modifier = Modifier.padding(16.dp),
+                            color = if (state.messageIsError) MaterialTheme.colorScheme.onErrorContainer
+                            else MaterialTheme.colorScheme.onPrimaryContainer,
+                        )
+                    }
+                }
+
+                AlertsSection(state, uriHandler = uriHandler, onAckLogout = { viewModel.ackLogoutWarning() })
+
+                StatusCard(state, viewModel, uriHandler, copy)
+
+                val connected = state.phase == TailscalePhase.HEALTHY || state.phase == TailscalePhase.DEGRADED
+                if (connected) {
+                    ConnectionDetailsCard(state.status, copy)
+                    if (state.status.health.isNotEmpty()) AdvisoriesCard(state.status.health)
+                }
+
+                // build_status short-circuits during an update, so every live field is null —
+                // rendering them would flash a false "disconnected".
+                if (state.status.enrolled &&
+                    state.phase != TailscalePhase.NOT_INSTALLED &&
+                    state.phase != TailscalePhase.UPDATING
+                ) {
+                    SettingsCard(state, viewModel)
+                }
+
+                if (state.phase != TailscalePhase.UPDATING) {
+                    MaintenanceCard(state, viewModel, copy)
+                }
+
+                if (state.status.enrolled) {
+                    DangerZoneCard(state, viewModel)
+                }
+            }
+        }
+    }
+}
+
+private fun withRemoteSession(body: String, remoteSession: Boolean): String =
+    if (remoteSession) "$body\n\n$COPY_REMOTE_SESSION_PARAGRAPH" else body
+
+/** Null unless key_expiry is set and less than 14 days out. Null expiry means "never" — the good outcome. */
+private fun daysUntilKeyExpiry(status: TailscaleStatus): Int? {
+    val at = status.keyExpiryAt ?: return null
+    val seconds = Duration.between(Instant.now(), at).seconds
+    if (seconds <= 0 || seconds >= 14L * 86_400) return null
+    return ((seconds + 86_399) / 86_400).toInt()
+}
+
+private fun formatKeyExpiry(status: TailscaleStatus): String {
+    val raw = status.keyExpiry ?: return "Never"
+    val at = status.keyExpiryAt ?: return raw
+    return SimpleDateFormat("MMM d, yyyy HH:mm", Locale.getDefault()).format(Date.from(at))
+}
+
+@Composable
+private fun AlertsSection(
+    state: TailscaleState,
+    uriHandler: UriHandler,
+    onAckLogout: () -> Unit,
+) {
+    state.passwordGateMessage?.let { serverMessage ->
+        // No retry and no login prompt: a 403 here is not an auth failure and cannot be
+        // fixed through the API.
+        AlertCard(
+            title = COPY_GATE_TITLE,
+            severity = TailscaleSeverity.CRITICAL,
+            body = COPY_GATE_BODY,
+            detail = serverMessage,
+        )
+    }
+
+    state.logoutWarning?.let { warning ->
+        AlertCard(
+            title = COPY_LOGOUT_WARNING_PREFIX,
+            severity = TailscaleSeverity.CRITICAL,
+            body = COPY_LOGOUT_WARNING_SUFFIX,
+            detail = warning,
+        ) {
+            Row {
+                TextButton(onClick = { uriHandler.openUri(URL_ADMIN_MACHINES) }) { Text(COPY_ADMIN_LINK) }
+                TextButton(onClick = onAckLogout) { Text(COPY_LOGOUT_WARNING_ACK) }
+            }
+        }
+    }
+
+    if (state.status.wakelockFailing) {
+        AlertCard(COPY_WAKELOCK_ALERT_TITLE, TailscaleSeverity.WARNING, COPY_WAKELOCK_ALERT_BODY)
+    }
+
+    if (state.status.expired) {
+        AlertCard(COPY_EXPIRED_TITLE, TailscaleSeverity.CRITICAL, COPY_EXPIRED_BODY)
+    }
+
+    daysUntilKeyExpiry(state.status)?.let { days ->
+        AlertCard("This router's key expires in $days days", TailscaleSeverity.WARNING, COPY_EXPIRING_BODY) {
+            TextButton(onClick = { uriHandler.openUri(URL_ADMIN_MACHINES) }) { Text(COPY_ADMIN_LINK) }
+        }
+    }
+
+    if (state.isRemoteSession) {
+        AlertCard(COPY_REMOTE_BANNER_TITLE, TailscaleSeverity.WARNING, COPY_REMOTE_BANNER_BODY)
+    }
+}
+
+@Composable
+private fun StatusCard(
+    state: TailscaleState,
+    viewModel: TailscaleViewModel,
+    uriHandler: UriHandler,
+    onCopy: (String) -> Unit,
+) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    state.phase.label,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold,
+                    color = severityColor(state.phase.severity),
+                )
+                if (state.phase.showsSpinner) {
+                    Spacer(modifier = Modifier.width(8.dp))
+                    CircularProgressIndicator(modifier = Modifier.size(16.dp), strokeWidth = 2.dp)
+                }
+            }
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                state.phaseDescription,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+
+            if (state.phase == TailscalePhase.UNKNOWN) {
+                Spacer(modifier = Modifier.height(8.dp))
+                InfoRow("Backend", state.status.backendState.orEmpty())
+            }
+
+            // status.error only exists while state == "starting"; every other phase's key is absent.
+            val startupError = state.status.error
+            if (state.phase == TailscalePhase.STARTING && !startupError.isNullOrEmpty()) {
+                var expanded by remember { mutableStateOf(false) }
+                TextButton(onClick = { expanded = !expanded }, contentPadding = PaddingValues(0.dp)) {
+                    Text(if (expanded) "Hide Details" else "Details")
+                }
+                if (expanded) {
+                    Text(
+                        startupError,
+                        style = MaterialTheme.typography.bodySmall,
+                        fontFamily = FontFamily.Monospace,
+                        modifier = Modifier.clickable { onCopy(startupError) },
+                    )
+                }
+            }
+
+            val enabled = state.actionsEnabled
+            when (state.phase) {
+                TailscalePhase.NOT_INSTALLED -> PrimaryAction("Install Tailscale", enabled) { viewModel.openUpdateSheet() }
+                TailscalePhase.NOT_SET_UP, TailscalePhase.AWAITING_SETUP ->
+                    PrimaryAction("Set Up Remote Access", enabled && !state.passwordGateBlocked) { viewModel.openEnrollSheet() }
+                TailscalePhase.TURNED_OFF ->
+                    PrimaryAction("Turn On Remote Access", enabled && !state.passwordGateBlocked) { viewModel.enable() }
+                TailscalePhase.NEEDS_LOGIN -> {
+                    PrimaryAction("Sign In Again", enabled && !state.passwordGateBlocked) { viewModel.openEnrollSheet() }
+                    Text(
+                        COPY_NEEDS_LOGIN_FOOTER,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                TailscalePhase.AWAITING_BROWSER_LOGIN -> {
+                    val url = state.status.loginUrl
+                    Spacer(modifier = Modifier.height(12.dp))
+                    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                        Button(onClick = { url?.let { uriHandler.openUri(it) } }, enabled = !url.isNullOrEmpty()) {
+                            Text("Open Sign-In Page")
+                        }
+                        TextButton(onClick = { url?.let(onCopy) }, enabled = !url.isNullOrEmpty()) {
+                            Text("Copy Link")
+                        }
+                    }
+                }
+                TailscalePhase.PENDING_APPROVAL ->
+                    PrimaryAction("Open Admin Console", true) { uriHandler.openUri(URL_ADMIN_MACHINES) }
+                TailscalePhase.DEGRADED ->
+                    if (state.degradedActionVisible) {
+                        PrimaryAction("Sign In Again", enabled && !state.passwordGateBlocked) { viewModel.openEnrollSheet() }
+                    }
+                else -> {}
+            }
+        }
+    }
+}
+
+@Composable
+private fun ColumnScope.PrimaryAction(label: String, enabled: Boolean, onClick: () -> Unit) {
+    Spacer(modifier = Modifier.height(12.dp))
+    Button(onClick = onClick, enabled = enabled, modifier = Modifier.fillMaxWidth()) { Text(label) }
+}
+
+@Composable
+private fun ConnectionDetailsCard(status: TailscaleStatus, onCopy: (String) -> Unit) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text("Connection", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
+            Spacer(modifier = Modifier.height(8.dp))
+            CopyableInfoRow("Tailscale IP", status.primaryIp, onCopy)
+            if (status.tailscaleIps.size > 1) {
+                CopyableInfoRow("Tailscale IPv6", status.tailscaleIps[1], onCopy)
+            }
+            CopyableInfoRow("MagicDNS name", status.displayDnsName, onCopy)
+            // Neutral: relayed is expected behind CGNAT-to-CGNAT, not a fault.
+            InfoRow("Path", status.pathDescription)
+            InfoRow("Key expiry", formatKeyExpiry(status))
+            InfoRow("Version", status.clientVersion.orEmpty())
+        }
+    }
+}
+
+@Composable
+private fun AdvisoriesCard(health: List<String>) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text("Advisories", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
+            Spacer(modifier = Modifier.height(8.dp))
+            health.forEach { advisory ->
+                Text(
+                    advisory,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(vertical = 2.dp),
+                )
+            }
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                COPY_ADVISORIES_FOOTER,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+@Composable
+private fun SettingsCard(state: TailscaleState, viewModel: TailscaleViewModel) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text("Settings", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
+            Spacer(modifier = Modifier.height(8.dp))
+            OutlinedTextField(
+                value = state.editHostname,
+                onValueChange = viewModel::setHostname,
+                label = { Text("Hostname") },
+                singleLine = true,
+                isError = state.hostnameError != null,
+                supportingText = state.hostnameError?.let { error -> @Composable { Text(error) } },
+                modifier = Modifier.fillMaxWidth(),
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            OutlinedTextField(
+                value = state.editRoutes,
+                onValueChange = viewModel::setRoutes,
+                label = { Text("Advertise routes") },
+                placeholder = { Text("192.168.0.0/24") },
+                singleLine = true,
+                isError = state.routesError != null,
+                supportingText = state.routesError?.let { error -> @Composable { Text(error) } },
+                modifier = Modifier.fillMaxWidth(),
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            ToggleRow("Tailscale SSH", state.editSsh) { viewModel.setSsh(it) }
+            ToggleRow("Keep router awake", state.editWakelock) { viewModel.setWakelock(it) }
+            Text(
+                COPY_WAKELOCK_FOOTER,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(modifier = Modifier.height(12.dp))
+            Button(
+                onClick = { viewModel.requestApplyConfig() },
+                enabled = state.actionsEnabled && state.configPatch.isNotEmpty(),
+            ) { Text("Apply") }
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                COPY_SETTINGS_FOOTER,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+@Composable
+private fun MaintenanceCard(state: TailscaleState, viewModel: TailscaleViewModel, onCopy: (String) -> Unit) {
+    val status = state.status
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text("Maintenance", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
+            Spacer(modifier = Modifier.height(8.dp))
+            InfoRow("Installed", if (status.installed) "Yes" else "No")
+            // "" does NOT mean "not installed" — it means no install this app performed.
+            InfoRow("Pinned version", status.pinnedVersion.ifEmpty { "Not managed by this app" })
+            InfoRow("Running version", status.clientVersion.orEmpty())
+
+            if (status.versionMismatch) {
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    "Installed ${status.pinnedVersion} but running ${status.clientVersion} — a version " +
+                        "swap may not have taken effect.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = severityColor(TailscaleSeverity.WARNING),
+                )
+            }
+
+            Spacer(modifier = Modifier.height(12.dp))
+            Button(onClick = { viewModel.openUpdateSheet() }, enabled = state.actionsEnabled) {
+                Text(if (status.installed) "Update Tailscale" else "Install Tailscale")
+            }
+
+            status.lastUpdate?.let { last ->
+                Spacer(modifier = Modifier.height(8.dp))
+                if (last.ok) {
+                    Text(
+                        "Updated to ${last.version}.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = severityColor(TailscaleSeverity.GOOD),
+                    )
+                } else {
+                    // Verbatim and copyable — these are diagnostic and specific.
+                    val detail = last.error ?: "unknown error"
+                    Text(
+                        "Update failed: $detail",
+                        style = MaterialTheme.typography.bodySmall,
+                        fontFamily = FontFamily.Monospace,
+                        color = MaterialTheme.colorScheme.error,
+                        modifier = Modifier.clickable { onCopy(detail) },
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                COPY_MAINTENANCE_FOOTER,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+@Composable
+private fun DangerZoneCard(state: TailscaleState, viewModel: TailscaleViewModel) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text("Danger Zone", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
+            Spacer(modifier = Modifier.height(4.dp))
+            TextButton(onClick = { viewModel.requestDisable() }, enabled = state.actionsEnabled) {
+                Text("Turn Off Remote Access", color = MaterialTheme.colorScheme.error)
+            }
+            if (state.phase == TailscalePhase.HEALTHY) {
+                Text(
+                    COPY_HEALTHY_TURN_OFF_FOOTER,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            TextButton(
+                onClick = { viewModel.requestLogout() },
+                enabled = state.actionsEnabled && !state.status.updating,
+            ) {
+                Text("Log Out of Tailscale", color = MaterialTheme.colorScheme.error)
+            }
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                COPY_DANGER_FOOTER,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+// MARK: - Dialogs
+
+@Composable
+private fun EnrollDialog(
+    connectEnabled: Boolean,
+    onOpenKeysPage: () -> Unit,
+    onDismiss: () -> Unit,
+    onAuthKey: (String) -> Unit,
+    onBrowserLogin: () -> Unit,
+) {
+    var useAuthKey by remember { mutableStateOf(true) }
+    // The key lives here and nowhere else: dismissing the dialog is what clears it.
+    var authKey by remember { mutableStateOf("") }
+    var reveal by remember { mutableStateOf(false) }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(COPY_ENROLL_TITLE) },
+        text = {
+            Column(
+                modifier = Modifier.verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                Text(COPY_ENROLL_INTRO, style = MaterialTheme.typography.bodyMedium)
+                TabRow(selectedTabIndex = if (useAuthKey) 0 else 1) {
+                    Tab(
+                        selected = useAuthKey,
+                        onClick = { useAuthKey = true },
+                        text = { Text(COPY_ENROLL_AUTHKEY_TAB) },
+                    )
+                    Tab(
+                        selected = !useAuthKey,
+                        onClick = { useAuthKey = false },
+                        text = { Text(COPY_ENROLL_BROWSER_TAB) },
+                    )
+                }
+                if (useAuthKey) {
+                    Text(
+                        COPY_ENROLL_AUTHKEY_GUIDANCE,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    TextButton(onClick = onOpenKeysPage, contentPadding = PaddingValues(0.dp)) {
+                        Text(COPY_ENROLL_KEYS_LINK)
+                    }
+                    OutlinedTextField(
+                        value = authKey,
+                        onValueChange = { authKey = it },
+                        label = { Text("Auth key") },
+                        placeholder = { Text("tskey-auth-...") },
+                        singleLine = true,
+                        visualTransformation = if (reveal) VisualTransformation.None else PasswordVisualTransformation(),
+                        trailingIcon = {
+                            IconButton(onClick = { reveal = !reveal }) {
+                                Icon(
+                                    if (reveal) Icons.Default.VisibilityOff else Icons.Default.Visibility,
+                                    contentDescription = if (reveal) "Hide auth key" else "Show auth key",
+                                )
+                            }
+                        },
+                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                } else {
+                    Text(
+                        COPY_ENROLL_BROWSER_GUIDANCE,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+        },
+        confirmButton = {
+            if (useAuthKey) {
+                TextButton(
+                    onClick = { onAuthKey(authKey) },
+                    enabled = connectEnabled && authKey.isNotBlank(),
+                ) { Text("Connect") }
+            } else {
+                TextButton(onClick = onBrowserLogin) { Text("Sign In With Tailscale") }
+            }
+        },
+        dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } },
+    )
+}
+
+@Composable
+private fun UpdateDialog(
+    isInstall: Boolean,
+    fetching: Boolean,
+    release: TailscaleRelease?,
+    releaseError: String?,
+    remoteSession: Boolean,
+    enrolled: Boolean,
+    onRetry: () -> Unit,
+    onDismiss: () -> Unit,
+    onConfirm: (String, String) -> Unit,
+) {
+    var advanced by remember { mutableStateOf(false) }
+    var manualVersion by remember { mutableStateOf("") }
+    var manualSha by remember { mutableStateOf("") }
+
+    // Typed input wins over the fetched values — Advanced is also the fallback when the lookup fails.
+    val version = manualVersion.trim().ifEmpty { release?.version.orEmpty() }
+    val sha = manualSha.trim().ifEmpty { release?.sha256.orEmpty() }
+    val versionError = manualVersion.trim().takeIf { it.isNotEmpty() }?.let { TailscaleValidator.version(it) }
+    val shaError = manualSha.trim().takeIf { it.isNotEmpty() }?.let { TailscaleValidator.sha256(it) }
+    val canConfirm = !fetching && version.isNotEmpty() && sha.isNotEmpty() &&
+        versionError == null && shaError == null
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(if (isInstall) "Install Tailscale" else "Update Tailscale") },
+        text = {
+            Column(
+                modifier = Modifier.verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                when {
+                    fetching -> Row(verticalAlignment = Alignment.CenterVertically) {
+                        CircularProgressIndicator(modifier = Modifier.size(16.dp), strokeWidth = 2.dp)
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text(COPY_RELEASE_FETCHING, style = MaterialTheme.typography.bodyMedium)
+                    }
+                    release != null -> {
+                        Text(
+                            "Latest release: Tailscale ${release.version}.",
+                            style = MaterialTheme.typography.bodyMedium,
+                            fontWeight = FontWeight.Bold,
+                        )
+                        Text(
+                            COPY_RELEASE_SOURCE,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                    // A lookup failure is this phone's internet, never the router's — don't render
+                    // it as an agent error.
+                    releaseError != null -> {
+                        Text(
+                            releaseError,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.error,
+                        )
+                        TextButton(onClick = onRetry, contentPadding = PaddingValues(0.dp)) { Text("Retry") }
+                    }
+                }
+
+                Text(
+                    COPY_UPDATE_DATA_WARNING,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                if (remoteSession) {
+                    Text(
+                        COPY_UPDATE_REMOTE_WARNING,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = severityColor(TailscaleSeverity.WARNING),
+                    )
+                }
+                if (!enrolled) {
+                    Text(
+                        COPY_UPDATE_UNENROLLED_WARNING,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+
+                TextButton(onClick = { advanced = !advanced }, contentPadding = PaddingValues(0.dp)) {
+                    Text("Advanced")
+                }
+                if (advanced) {
+                    OutlinedTextField(
+                        value = manualVersion,
+                        onValueChange = { manualVersion = it },
+                        label = { Text("Version") },
+                        singleLine = true,
+                        isError = versionError != null,
+                        supportingText = versionError?.let { error -> @Composable { Text(error) } },
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                    OutlinedTextField(
+                        value = manualSha,
+                        onValueChange = { manualSha = it },
+                        label = { Text("SHA-256") },
+                        singleLine = true,
+                        isError = shaError != null,
+                        supportingText = shaError?.let { error -> @Composable { Text(error) } },
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = { onConfirm(version, sha) }, enabled = canConfirm) {
+                Text(if (isInstall) "Install" else "Update")
+            }
+        },
+        dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } },
+    )
+}
+
+@Composable
+private fun ConfirmDialog(
+    title: String,
+    message: String,
+    confirmLabel: String,
+    onDismiss: () -> Unit,
+    onConfirm: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(title) },
+        text = { Text(message) },
+        confirmButton = {
+            TextButton(onClick = onConfirm) { Text(confirmLabel, color = MaterialTheme.colorScheme.error) }
+        },
+        dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } },
+    )
+}
+
+/** Local-only gate against accidental taps and borrowed phones — the password is never sent. */
+@Composable
+private fun PasswordConfirmDialog(
+    title: String,
+    message: String,
+    confirmLabel: String,
+    verify: (String) -> Boolean,
+    onDismiss: () -> Unit,
+    onConfirm: () -> Unit,
+) {
+    var value by remember { mutableStateOf("") }
+    var wrong by remember { mutableStateOf(false) }
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(title) },
+        text = {
+            Column(
+                modifier = Modifier.verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                Text(message, style = MaterialTheme.typography.bodyMedium)
+                OutlinedTextField(
+                    value = value,
+                    onValueChange = { value = it; wrong = false },
+                    label = { Text("Router password") },
+                    singleLine = true,
+                    isError = wrong,
+                    visualTransformation = PasswordVisualTransformation(),
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
+                    supportingText = if (wrong) {
+                        @Composable { Text("Incorrect password.") }
+                    } else {
+                        null
+                    },
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(
+                onClick = { if (verify(value)) onConfirm() else wrong = true },
+                enabled = value.isNotBlank(),
+            ) { Text(confirmLabel, color = MaterialTheme.colorScheme.error) }
+        },
+        dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } },
+    )
+}
+
+// MARK: - Shared bits
+
+@Composable
+private fun severityColor(severity: TailscaleSeverity): Color = when (severity) {
+    TailscaleSeverity.NEUTRAL -> MaterialTheme.colorScheme.onSurfaceVariant
+    TailscaleSeverity.GOOD -> Color(0xFF2E7D32)
+    TailscaleSeverity.WARNING -> Color(0xFFE65100)
+    TailscaleSeverity.CRITICAL -> MaterialTheme.colorScheme.error
+}
+
+@Composable
+private fun AlertCard(
+    title: String,
+    severity: TailscaleSeverity,
+    body: String,
+    detail: String? = null,
+    content: @Composable ColumnScope.() -> Unit = {},
+) {
+    val critical = severity == TailscaleSeverity.CRITICAL
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = if (critical) MaterialTheme.colorScheme.errorContainer
+            else MaterialTheme.colorScheme.surfaceVariant,
+        ),
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(
+                title,
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.Bold,
+                color = if (critical) MaterialTheme.colorScheme.onErrorContainer else severityColor(severity),
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                body,
+                style = MaterialTheme.typography.bodySmall,
+                color = if (critical) MaterialTheme.colorScheme.onErrorContainer
+                else MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            detail?.let {
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    it,
+                    style = MaterialTheme.typography.bodySmall,
+                    fontFamily = FontFamily.Monospace,
+                    color = if (critical) MaterialTheme.colorScheme.onErrorContainer
+                    else MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            content()
+        }
+    }
+}
+
+@Composable
+private fun CopyableInfoRow(label: String, value: String?, onCopy: (String) -> Unit) {
+    val shown = value?.takeIf { it.isNotBlank() }
+    InfoRow(label, shown.orEmpty(), onClick = shown?.let { v -> { onCopy(v) } })
+}
+
+@Composable
+private fun InfoRow(label: String, value: String, onClick: (() -> Unit)? = null) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .then(if (onClick != null) Modifier.clickable(onClick = onClick) else Modifier)
+            .padding(vertical = 2.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Text(label, style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        Text(value.ifBlank { "--" }, style = MaterialTheme.typography.bodyMedium, fontFamily = FontFamily.Monospace)
+    }
+}
+
+@Composable
+private fun ToggleRow(label: String, checked: Boolean, onToggle: (Boolean) -> Unit) {
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(label, style = MaterialTheme.typography.bodyLarge)
+        Switch(checked = checked, onCheckedChange = onToggle)
+    }
+}

--- a/mobile/android/OpenU60/app/src/main/java/com/openu60/feature/router/tailscale/TailscaleViewModel.kt
+++ b/mobile/android/OpenU60/app/src/main/java/com/openu60/feature/router/tailscale/TailscaleViewModel.kt
@@ -1,0 +1,1018 @@
+package com.openu60.feature.router.tailscale
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.openu60.core.model.DeviceParser
+import com.openu60.core.model.TailscaleParser
+import com.openu60.core.model.TailscaleRelease
+import com.openu60.core.model.TailscaleStatus
+import com.openu60.core.model.TailscaleValidator
+import com.openu60.core.network.AgentClient
+import com.openu60.core.network.AgentError
+import com.openu60.core.network.AuthManager
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import java.net.URI
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+
+private const val PATH_STATUS = "/api/tailscale/status"
+private const val PATH_SETUP = "/api/tailscale/setup"
+private const val PATH_LOGIN_URL = "/api/tailscale/login-url"
+private const val PATH_ENABLE = "/api/tailscale/enable"
+private const val PATH_DISABLE = "/api/tailscale/disable"
+private const val PATH_CONFIG = "/api/tailscale/config"
+private const val PATH_LOGOUT = "/api/tailscale/logout"
+private const val PATH_UPDATE = "/api/tailscale/update"
+
+private const val RELEASE_BASE = "https://pkgs.tailscale.com/stable"
+private const val RELEASE_INDEX_URL = "$RELEASE_BASE/?mode=json"
+
+/** GET /status serves a 10s cache, so a faster poll returns the byte-identical object. */
+private const val POLL_ACTIVE_MS = 10_000L
+private const val POLL_IDLE_MS = 30_000L
+
+private const val PREWARM_CAP_POLLS = 18
+private const val ENABLE_CAP_POLLS = 18
+private const val VERIFY_CAP_POLLS = 24
+private const val BROWSER_LOGIN_CAP_POLLS = 31
+private const val DISABLE_CAP_POLLS = 3
+private const val UPDATE_CAP_POLLS = 40
+private const val MAX_POLL_FAILURES = 6
+
+/** The agent's own monitor rebinds at 2 bad cycles and restarts at 4 — no action before then. */
+private const val DEGRADED_RECOVERING_POLLS = 4
+
+private val PREWARM_READY_STATES =
+    setOf("awaiting_setup", "needs_login", "connecting", "paused", "healthy", "degraded", "pending_approval")
+private val ENABLE_TERMINAL_STATES =
+    setOf("healthy", "degraded", "needs_login", "awaiting_setup", "pending_approval")
+
+private const val COPY_PREWARM_PROGRESS = "Starting Tailscale… this can take up to 2 minutes on first run."
+private const val COPY_PREWARM_TIMEOUT =
+    "Tailscale isn't starting. Check that the router has mobile data and its clock is set."
+private const val COPY_ENROLL_SUCCESS = "This router is now on your tailnet."
+private const val COPY_ENROLL_PENDING_APPROVAL =
+    "Setup completed. Approve this router in your Tailscale admin console."
+private const val COPY_ENROLL_VERIFY_ELAPSED =
+    "Setup didn't complete. Enter a fresh auth key — one-off keys can't be reused."
+private const val COPY_BROWSER_LOGIN_ELAPSED = "Sign-in didn't complete in time. Try again."
+private const val COPY_ENABLE_ACCEPTED = "Turning on remote access…"
+private const val COPY_ENABLE_ELAPSED = "Still starting — check back shortly."
+private const val COPY_DISABLE_SUCCESS = "Remote access is off."
+private const val COPY_CONFIG_APPLIED = "Settings applied."
+private const val COPY_CONFIG_PERSISTED = "Saved. These will apply the next time Tailscale starts."
+private const val COPY_CONFIG_REJECTED = "Tailscale rejected the change. Nothing was saved."
+private const val COPY_LOGOUT_SUCCESS = "Logged out. This router has been removed from your tailnet."
+private const val COPY_LOGOUT_AMBIGUOUS =
+    "Logged out. If this router still appears in your admin console, remove it there."
+private const val COPY_LOGOUT_BLOCKED = "Can't log out while an update is running."
+private const val COPY_UPDATE_IN_PROGRESS =
+    "Updating Tailscale. This can take several minutes. Don't power off the router."
+private const val COPY_UPDATE_UNKNOWN =
+    "Update finished, but the result is unknown (the agent may have restarted). Check the running version below."
+private const val COPY_UPDATE_VERSION_UNCHANGED = "Update reported success but the version didn't change."
+private const val COPY_RELEASE_FAILED =
+    "Couldn't reach pkgs.tailscale.com to look up the latest release. Check this phone's internet " +
+        "connection, or enter a version and checksum manually under Advanced."
+private const val COPY_RELEASE_NO_ARM64 =
+    "The latest Tailscale release doesn't publish an arm64 build, which this router needs. Enter a " +
+        "version and checksum manually under Advanced."
+private const val COPY_RELEASE_BAD_SHA =
+    "pkgs.tailscale.com returned a checksum this app couldn't read. Enter a version and checksum " +
+        "manually under Advanced."
+private const val COPY_LOST_CONNECTION = "Lost connection to the router."
+private const val COPY_COPIED = "Copied to clipboard"
+
+enum class TailscaleSeverity { NEUTRAL, GOOD, WARNING, CRITICAL }
+
+/**
+ * Ordered to match the iOS enum and the spec's phase table — the derivation is duplicated in two
+ * languages with no shared source, so a side-by-side diff has to stay readable.
+ */
+enum class TailscalePhase(
+    val label: String,
+    val severity: TailscaleSeverity,
+    val showsSpinner: Boolean,
+) {
+    NOT_INSTALLED("Not installed", TailscaleSeverity.NEUTRAL, false),
+    UPDATING("Updating", TailscaleSeverity.NEUTRAL, true),
+    NOT_SET_UP("Not set up", TailscaleSeverity.NEUTRAL, false),
+    TURNED_OFF("Off", TailscaleSeverity.NEUTRAL, false),
+    TURNING_OFF("Turning off…", TailscaleSeverity.NEUTRAL, true),
+    LOGGING_OUT("Logging out…", TailscaleSeverity.NEUTRAL, true),
+    STARTING("Starting…", TailscaleSeverity.NEUTRAL, true),
+    ENROLLING("Setting up…", TailscaleSeverity.NEUTRAL, true),
+    VERIFYING_ENROLLMENT("Finishing setup…", TailscaleSeverity.NEUTRAL, true),
+    AWAITING_BROWSER_LOGIN("Waiting for sign-in", TailscaleSeverity.NEUTRAL, true),
+    AWAITING_SETUP("Not signed in", TailscaleSeverity.NEUTRAL, false),
+    NEEDS_LOGIN("Sign-in required", TailscaleSeverity.CRITICAL, false),
+    PENDING_APPROVAL("Waiting for approval", TailscaleSeverity.WARNING, true),
+    PAUSED("Reconnecting…", TailscaleSeverity.NEUTRAL, true),
+    HEALTHY("Connected", TailscaleSeverity.GOOD, false),
+    DEGRADED("Connection problem", TailscaleSeverity.WARNING, true),
+    UNKNOWN("Unknown", TailscaleSeverity.NEUTRAL, false),
+}
+
+enum class TailscaleOp {
+    NONE,
+    ENABLING,
+    PREWARMING,
+    ENROLLING,
+    VERIFYING_ENROLLMENT,
+    AWAITING_BROWSER_LOGIN,
+    DISABLING,
+    LOGGING_OUT,
+    UPDATING,
+    SAVING_CONFIG,
+}
+
+sealed class TailscaleConfigConfirm {
+    data object AllowSsh : TailscaleConfigConfirm()
+    data class AdvertiseRoute(val cidr: String) : TailscaleConfigConfirm()
+    data object AllowSleep : TailscaleConfigConfirm()
+}
+
+data class TailscaleState(
+    val status: TailscaleStatus = TailscaleStatus.empty,
+    val op: TailscaleOp = TailscaleOp.NONE,
+    val isLoading: Boolean = false,
+    val message: String? = null,
+    val messageIsError: Boolean = false,
+    val initialLoadDone: Boolean = false,
+    val hasSavedPassword: Boolean = false,
+    val degradedPolls: Int = 0,
+    val isRemoteSession: Boolean = false,
+    val passwordGateMessage: String? = null,
+    val logoutWarning: String? = null,
+    val editHostname: String = "",
+    val editRoutes: String = "",
+    val editSsh: Boolean = false,
+    val editWakelock: Boolean = true,
+    val hostnameError: String? = null,
+    val routesError: String? = null,
+    val configConfirms: List<TailscaleConfigConfirm> = emptyList(),
+    val showEnrollSheet: Boolean = false,
+    val showUpdateSheet: Boolean = false,
+    val showDisableConfirm: Boolean = false,
+    val showLogoutConfirm: Boolean = false,
+    val releaseFetching: Boolean = false,
+    val release: TailscaleRelease? = null,
+    val releaseError: String? = null,
+) {
+    val phase: TailscalePhase get() = derivePhase(status, op)
+
+    /** Not fixable from the API, so it disables the enable-path actions instead of retrying. */
+    val passwordGateBlocked: Boolean get() = passwordGateMessage != null
+
+    val actionsEnabled: Boolean get() =
+        !isLoading && op == TailscaleOp.NONE && phase != TailscalePhase.UPDATING
+
+    val phaseDescription: String get() = when (phase) {
+        TailscalePhase.NOT_INSTALLED ->
+            "Tailscale isn't installed on this router yet."
+        TailscalePhase.UPDATING ->
+            "Installing Tailscale. This can take several minutes over mobile data. Don't power off the router."
+        TailscalePhase.NOT_SET_UP ->
+            "Connect this router to your tailnet to reach it from anywhere."
+        TailscalePhase.TURNED_OFF ->
+            "Remote access is off. This router's sign-in is saved."
+        TailscalePhase.TURNING_OFF ->
+            "Disconnecting from your tailnet."
+        TailscalePhase.LOGGING_OUT ->
+            "Removing this router's Tailscale identity."
+        TailscalePhase.STARTING ->
+            "Waiting for the router's clock and mobile data. This can take up to 2 minutes."
+        TailscalePhase.ENROLLING ->
+            "Connecting this router to your tailnet. This can take up to 2 minutes."
+        TailscalePhase.VERIFYING_ENROLLMENT ->
+            "The router is still working. Checking whether setup completed."
+        TailscalePhase.AWAITING_BROWSER_LOGIN ->
+            "Open the sign-in page and approve this router. This link is valid for about 5 minutes."
+        TailscalePhase.AWAITING_SETUP ->
+            "Tailscale is running but this router hasn't joined a tailnet yet."
+        TailscalePhase.NEEDS_LOGIN ->
+            if (status.expired) "This router's node key expired. Sign in again to restore remote access."
+            else "This router's sign-in is no longer valid. Sign in again to restore remote access."
+        TailscalePhase.PENDING_APPROVAL ->
+            "Approve this router in the Tailscale admin console. Nothing can be done from this app."
+        TailscalePhase.PAUSED ->
+            "Tailscale is reconnecting. This usually clears within a minute."
+        TailscalePhase.HEALTHY ->
+            status.displayDnsName ?: "This router is on your tailnet."
+        TailscalePhase.DEGRADED ->
+            if (degradedPolls <= DEGRADED_RECOVERING_POLLS)
+                "The router is signed in but not reachable. Recovering automatically."
+            else "The router is signed in but still not reachable."
+        TailscalePhase.UNKNOWN ->
+            "The router reported a state this app doesn't recognize."
+    }
+
+    val degradedActionVisible: Boolean get() =
+        phase == TailscalePhase.DEGRADED && degradedPolls > DEGRADED_RECOVERING_POLLS
+
+    /**
+     * Only the changed fields: /config is schedulable and a web dashboard exists, so a
+     * full-state write can silently revert someone else's concurrent change. Values are real
+     * JSON types — TsConfigPatch is native serde_json, unlike the stringly-typed ubus endpoints.
+     */
+    val configPatch: Map<String, Any?> get() {
+        val patch = mutableMapOf<String, Any?>()
+        val trimmedHostname = editHostname.trim()
+        if (trimmedHostname != status.hostname) patch["hostname"] = trimmedHostname
+        val routes = TailscaleValidator.parseRoutes(editRoutes)
+        if (routes != status.advertiseRoutes) patch["advertise_routes"] = routes
+        if (editWakelock != status.holdWakelock) patch["hold_wakelock"] = editWakelock
+        if (editSsh != status.tailscaleSsh) patch["tailscale_ssh"] = editSsh
+        return patch
+    }
+}
+
+/**
+ * First match wins. `state` alone is insufficient: build_status returns "disabled" before the CLI
+ * is ever called, so a fresh install and a deliberate turn-off are the same string and only
+ * `enrolled` separates them. The enabled-guards on paused/respawning cover the POST /disable race,
+ * where the daemon is still alive for a moment after the desired state flipped.
+ */
+private fun derivePhase(status: TailscaleStatus, op: TailscaleOp): TailscalePhase {
+    if (op == TailscaleOp.UPDATING || status.updating || status.state == "updating") {
+        return TailscalePhase.UPDATING
+    }
+    if (status.state == "not_installed") return TailscalePhase.NOT_INSTALLED
+
+    if (op == TailscaleOp.ENROLLING) return TailscalePhase.ENROLLING
+    if (op == TailscaleOp.VERIFYING_ENROLLMENT) return TailscalePhase.VERIFYING_ENROLLMENT
+    if (op == TailscaleOp.AWAITING_BROWSER_LOGIN &&
+        status.state != "healthy" &&
+        status.state != "pending_approval"
+    ) {
+        return TailscalePhase.AWAITING_BROWSER_LOGIN
+    }
+    if (op == TailscaleOp.PREWARMING || op == TailscaleOp.ENABLING) return TailscalePhase.STARTING
+    if (op == TailscaleOp.DISABLING) return TailscalePhase.TURNING_OFF
+    if (op == TailscaleOp.LOGGING_OUT) return TailscalePhase.LOGGING_OUT
+
+    return when (status.state) {
+        "disabled" -> if (status.enrolled) TailscalePhase.TURNED_OFF else TailscalePhase.NOT_SET_UP
+        "paused" -> if (status.enabled) TailscalePhase.PAUSED else TailscalePhase.TURNING_OFF
+        "respawning" -> if (status.enabled) TailscalePhase.STARTING else TailscalePhase.TURNING_OFF
+        "starting" -> TailscalePhase.STARTING
+        "connecting" -> TailscalePhase.STARTING
+        "awaiting_setup" -> TailscalePhase.AWAITING_SETUP
+        "needs_login" -> TailscalePhase.NEEDS_LOGIN
+        "pending_approval" -> TailscalePhase.PENDING_APPROVAL
+        "healthy" -> TailscalePhase.HEALTHY
+        "degraded" -> TailscalePhase.DEGRADED
+        else -> TailscalePhase.UNKNOWN
+    }
+}
+
+@HiltViewModel
+class TailscaleViewModel @Inject constructor(
+    private val agentClient: AgentClient,
+    private val authManager: AuthManager,
+) : ViewModel() {
+
+    private val _state = MutableStateFlow(TailscaleState())
+    val state: StateFlow<TailscaleState> = _state.asStateFlow()
+
+    private var pollingJob: Job? = null
+    private var pollFailures = 0
+    private var reauthAttempted = false
+
+    /**
+     * The circuit breaker has fired. An op's cap copy ("Tailscale isn't starting", "Setup didn't
+     * complete") must not overwrite it — when the router stopped answering at all, that is the
+     * real story and the cap copy sends the user chasing the wrong thing.
+     */
+    private val connectionLost: Boolean get() = pollFailures >= MAX_POLL_FAILURES
+
+    // Must not go through AgentClient: that is bound to the router and attaches the agent's
+    // bearer token, which must never be sent to pkgs.tailscale.com.
+    private val releaseClient = OkHttpClient.Builder()
+        .connectTimeout(10, TimeUnit.SECONDS)
+        .readTimeout(20, TimeUnit.SECONDS)
+        .build()
+
+    init {
+        _state.value = _state.value.copy(hasSavedPassword = authManager.savedPassword.isNotBlank())
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        stopPolling()
+    }
+
+    fun refresh() {
+        viewModelScope.launch {
+            val firstLoad = !_state.value.initialLoadDone
+            // Clearing up front is what makes a stale failure banner clearable: on success nothing
+            // reinstates it, and on failure fetchStatus writes the fresh one.
+            _state.value = _state.value.copy(isLoading = true, message = null)
+            fetchStatus(reportFailure = true)
+            _state.value = _state.value.copy(isLoading = false)
+            // An update outlives this ViewModel, so a re-entered screen resumes the watch
+            // rather than assuming the poll survived.
+            if (firstLoad && _state.value.status.updating && _state.value.op == TailscaleOp.NONE) {
+                setOp(TailscaleOp.UPDATING)
+                watchUpdate(null)
+            }
+            if (_state.value.op == TailscaleOp.NONE) startPolling()
+        }
+    }
+
+    // MARK: - Enrollment
+
+    fun openEnrollSheet() {
+        if (!_state.value.actionsEnabled || _state.value.passwordGateBlocked) return
+        _state.value = _state.value.copy(showEnrollSheet = true)
+    }
+
+    fun dismissEnrollSheet() {
+        _state.value = _state.value.copy(showEnrollSheet = false)
+    }
+
+    /**
+     * The key is a parameter and never enters TailscaleState — a tailnet-wide bearer credential
+     * has no business in observable state, and it is never persisted, logged or retried.
+     */
+    fun setup(authKey: String) {
+        val key = authKey.trim()
+        if (key.isEmpty() || _state.value.op != TailscaleOp.NONE) return
+        viewModelScope.launch {
+            stopPolling()
+            try {
+                dismissEnrollSheet()
+                if (!prewarm()) return@launch
+                setOp(TailscaleOp.ENROLLING)
+                showMessage(null, false)
+                try {
+                    val data = withReauth { agentClient.postJSONSlow(PATH_SETUP, mapOf("auth_key" to key)) }
+                    // The 200 body IS the refreshed status payload — no follow-up GET.
+                    adoptStatus(TailscaleParser.parse(data))
+                    setOp(TailscaleOp.NONE)
+                    reportEnrollmentOutcome()
+                } catch (e: AgentError.ApiError) {
+                    setOp(TailscaleOp.NONE)
+                    when (e.status) {
+                        403 -> blockPasswordGate(e.serverMessage)
+                        502 -> setError(
+                            "Setup failed: ${e.serverMessage}. Enter a fresh auth key — " +
+                                "one-off keys can't be reused."
+                        )
+                        else -> setError(e.serverMessage)
+                    }
+                } catch (_: AgentError.Timeout) {
+                    // Not an error: /setup blocks for up to ~90s server-side and the enrollment is
+                    // very likely still landing. Re-sending the key would 409 or burn a fresh one.
+                    setOp(TailscaleOp.VERIFYING_ENROLLMENT)
+                    val done = awaitStatus(VERIFY_CAP_POLLS) {
+                        it.state == "healthy" || it.state == "pending_approval"
+                    }
+                    setOp(TailscaleOp.NONE)
+                    when {
+                        done -> reportEnrollmentOutcome()
+                        !connectionLost -> setError(COPY_ENROLL_VERIFY_ELAPSED)
+                    }
+                } catch (e: Exception) {
+                    setOp(TailscaleOp.NONE)
+                    setError(e.message)
+                }
+            } finally {
+                startPolling()
+            }
+        }
+    }
+
+    fun startBrowserLogin() {
+        if (_state.value.op != TailscaleOp.NONE) return
+        viewModelScope.launch {
+            stopPolling()
+            try {
+                dismissEnrollSheet()
+                if (!prewarm()) return@launch
+                setOp(TailscaleOp.AWAITING_BROWSER_LOGIN)
+                showMessage(null, false)
+                try {
+                    val data = withReauth { agentClient.postJSONSlow(PATH_LOGIN_URL) }
+                    // 202 and 200 are indistinguishable through the raw-JSON API, so branch on
+                    // the payload: `login_url as? String ?: ""` would silently drop the pending case.
+                    val pending = DeviceParser.asBool(data["pending"])
+                    val url = TailscaleParser.asString(data["login_url"])
+                    if (!pending && !url.isNullOrEmpty()) adoptLoginUrl(url)
+                } catch (e: AgentError.ApiError) {
+                    setOp(TailscaleOp.NONE)
+                    if (e.status == 403) blockPasswordGate(e.serverMessage) else setError(e.serverMessage)
+                    return@launch
+                } catch (_: AgentError.Timeout) {
+                    // Fall through to polling: the URL surfaces via /status either way.
+                } catch (e: Exception) {
+                    setOp(TailscaleOp.NONE)
+                    setError(e.message)
+                    return@launch
+                }
+
+                // needs_login is deliberately NOT terminal here: it is the *starting* state of the
+                // re-auth path, so exiting on it would kill the flow before the URL appears.
+                val done = awaitStatus(BROWSER_LOGIN_CAP_POLLS) {
+                    it.state == "healthy" || it.state == "pending_approval"
+                }
+                setOp(TailscaleOp.NONE)
+                when {
+                    done -> reportEnrollmentOutcome()
+                    !connectionLost -> setError(COPY_BROWSER_LOGIN_ELAPSED)
+                }
+            } finally {
+                startPolling()
+            }
+        }
+    }
+
+    /**
+     * Never call /setup or /login-url against a cold daemon: ensure_daemon_ready can burn ~180s
+     * inside the request. Pre-warming also surfaces the 403 password gate before the user pastes
+     * a secret, and the needs_login re-auth path 409s without it.
+     */
+    private suspend fun prewarm(): Boolean {
+        if (_state.value.status.enabled) return true
+        setOp(TailscaleOp.PREWARMING)
+        showMessage(COPY_PREWARM_PROGRESS, false)
+        try {
+            withReauth { agentClient.postJSON(PATH_ENABLE) }
+        } catch (e: AgentError.ApiError) {
+            setOp(TailscaleOp.NONE)
+            handleEnablePathError(e)
+            return false
+        } catch (e: Exception) {
+            setOp(TailscaleOp.NONE)
+            setError(e.message)
+            return false
+        }
+        clearPasswordGate()
+
+        if (!awaitStatus(PREWARM_CAP_POLLS) { it.state in PREWARM_READY_STATES }) {
+            setOp(TailscaleOp.NONE)
+            if (!connectionLost) setError(COPY_PREWARM_TIMEOUT)
+            return false
+        }
+        setOp(TailscaleOp.NONE)
+        // Already enrolled and connected — there is nothing left to enroll.
+        if (_state.value.status.state == "healthy") {
+            showMessage(null, false)
+            return false
+        }
+        return true
+    }
+
+    private fun reportEnrollmentOutcome() {
+        when (_state.value.status.state) {
+            "healthy" -> showMessage(COPY_ENROLL_SUCCESS, false)
+            "pending_approval" -> showMessage(COPY_ENROLL_PENDING_APPROVAL, false)
+        }
+    }
+
+    // MARK: - Enable / disable
+
+    fun enable() {
+        if (_state.value.op != TailscaleOp.NONE || _state.value.passwordGateBlocked) return
+        viewModelScope.launch {
+            stopPolling()
+            try {
+                setOp(TailscaleOp.ENABLING)
+                showMessage(COPY_ENABLE_ACCEPTED, false)
+                try {
+                    withReauth { agentClient.postJSON(PATH_ENABLE) }
+                } catch (e: AgentError.ApiError) {
+                    setOp(TailscaleOp.NONE)
+                    handleEnablePathError(e)
+                    return@launch
+                } catch (e: Exception) {
+                    setOp(TailscaleOp.NONE)
+                    setError(e.message)
+                    return@launch
+                }
+                clearPasswordGate()
+                // respawning and a transient paused are both expected here for up to ~2 minutes
+                // and are not failures.
+                val settled = awaitStatus(ENABLE_CAP_POLLS) { it.state in ENABLE_TERMINAL_STATES }
+                setOp(TailscaleOp.NONE)
+                if (!connectionLost) showMessage(if (settled) null else COPY_ENABLE_ELAPSED, false)
+            } finally {
+                startPolling()
+            }
+        }
+    }
+
+    fun requestDisable() {
+        if (!_state.value.actionsEnabled) return
+        _state.value = _state.value.copy(showDisableConfirm = true)
+    }
+
+    fun dismissDisableConfirm() {
+        _state.value = _state.value.copy(showDisableConfirm = false)
+    }
+
+    fun disable() {
+        _state.value = _state.value.copy(showDisableConfirm = false)
+        if (_state.value.op != TailscaleOp.NONE) return
+        viewModelScope.launch {
+            stopPolling()
+            try {
+                setOp(TailscaleOp.DISABLING)
+                try {
+                    withReauth { agentClient.postJSONSlow(PATH_DISABLE) }
+                } catch (e: AgentError.ApiError) {
+                    setOp(TailscaleOp.NONE)
+                    setError(e.serverMessage)
+                    return@launch
+                } catch (e: Exception) {
+                    setOp(TailscaleOp.NONE)
+                    setError(e.message)
+                    return@launch
+                }
+                showMessage(COPY_DISABLE_SUCCESS, false)
+                // kill_child only SIGTERMs and the supervisor clears child_pid afterwards, so
+                // /status keeps reporting a live daemon for a moment. TURNING_OFF absorbs it.
+                awaitStatus(DISABLE_CAP_POLLS) { it.state == "disabled" }
+                setOp(TailscaleOp.NONE)
+            } finally {
+                startPolling()
+            }
+        }
+    }
+
+    // MARK: - Settings
+
+    fun setHostname(value: String) {
+        _state.value = _state.value.copy(editHostname = value, hostnameError = null)
+    }
+
+    fun setRoutes(value: String) {
+        _state.value = _state.value.copy(editRoutes = value, routesError = null)
+    }
+
+    fun setSsh(value: Boolean) {
+        _state.value = _state.value.copy(editSsh = value)
+    }
+
+    fun setWakelock(value: Boolean) {
+        _state.value = _state.value.copy(editWakelock = value)
+    }
+
+    fun requestApplyConfig() {
+        val s = _state.value
+        val hostnameError = TailscaleValidator.hostname(s.editHostname)
+        val routesError = TailscaleValidator.routes(s.editRoutes)
+        if (hostnameError != null || routesError != null) {
+            _state.value = s.copy(hostnameError = hostnameError, routesError = routesError)
+            return
+        }
+        if (s.configPatch.isEmpty()) return
+
+        val confirms = mutableListOf<TailscaleConfigConfirm>()
+        if (s.editSsh && !s.status.tailscaleSsh) confirms.add(TailscaleConfigConfirm.AllowSsh)
+        TailscaleValidator.parseRoutes(s.editRoutes)
+            .filterNot { it in s.status.advertiseRoutes }
+            .forEach { confirms.add(TailscaleConfigConfirm.AdvertiseRoute(it)) }
+        if (!s.editWakelock && s.status.holdWakelock) confirms.add(TailscaleConfigConfirm.AllowSleep)
+
+        if (confirms.isEmpty()) applyConfig() else _state.value = s.copy(configConfirms = confirms)
+    }
+
+    fun acceptConfigConfirm() {
+        val rest = _state.value.configConfirms.drop(1)
+        _state.value = _state.value.copy(configConfirms = rest)
+        if (rest.isEmpty()) applyConfig()
+    }
+
+    fun dismissConfigConfirms() {
+        _state.value = _state.value.copy(configConfirms = emptyList())
+    }
+
+    private fun applyConfig() {
+        val patch = _state.value.configPatch
+        if (patch.isEmpty() || _state.value.op != TailscaleOp.NONE) return
+        viewModelScope.launch {
+            stopPolling()
+            try {
+                setOp(TailscaleOp.SAVING_CONFIG)
+                _state.value = _state.value.copy(isLoading = true)
+                try {
+                    val data = withReauth { agentClient.putJSONSlow(PATH_CONFIG, patch) }
+                    // The 200 body IS the refreshed status payload — no follow-up GET.
+                    val status = TailscaleParser.parse(data)
+                    adoptStatus(status)
+                    seedBuffers(status)
+                    // The agent only shells `tailscale set` when the daemon is live and enrolled;
+                    // otherwise it silently persists for next start. Both return 200.
+                    val applied = status.enabled && status.daemonRunning && status.enrolled
+                    showMessage(if (applied) COPY_CONFIG_APPLIED else COPY_CONFIG_PERSISTED, false)
+                } catch (e: AgentError.ApiError) {
+                    if (e.status == 502) {
+                        // Transactional: the patch was applied to a candidate copy and nothing persisted.
+                        setError(COPY_CONFIG_REJECTED)
+                        fetchStatus()
+                        seedBuffers(_state.value.status)
+                    } else {
+                        setError(e.serverMessage)
+                    }
+                } catch (e: Exception) {
+                    setError(e.message)
+                }
+                setOp(TailscaleOp.NONE)
+                _state.value = _state.value.copy(isLoading = false)
+            } finally {
+                startPolling()
+            }
+        }
+    }
+
+    // MARK: - Logout
+
+    fun requestLogout() {
+        if (!_state.value.actionsEnabled || _state.value.status.updating) return
+        _state.value = _state.value.copy(showLogoutConfirm = true)
+    }
+
+    fun dismissLogoutConfirm() {
+        _state.value = _state.value.copy(showLogoutConfirm = false)
+    }
+
+    /** A UX gate against accidental taps and borrowed phones — never transmitted, never server-enforced. */
+    fun verifyPassword(input: String): Boolean {
+        val saved = authManager.savedPassword
+        return saved.isNotBlank() && input == saved
+    }
+
+    fun logout() {
+        _state.value = _state.value.copy(showLogoutConfirm = false)
+        if (_state.value.op != TailscaleOp.NONE) return
+        viewModelScope.launch {
+            stopPolling()
+            try {
+                setOp(TailscaleOp.LOGGING_OUT)
+                try {
+                    val data = withReauth { agentClient.postJSONSlow(PATH_LOGOUT) }
+                    // Logout returns 200 even when it fails; `warning` is the only failure channel.
+                    val warning = TailscaleParser.asString(data["warning"])
+                    if (warning.isNullOrEmpty()) {
+                        showMessage(COPY_LOGOUT_SUCCESS, false)
+                    } else {
+                        _state.value = _state.value.copy(logoutWarning = warning)
+                        showMessage(null, false)
+                    }
+                } catch (e: AgentError.ApiError) {
+                    if (e.status == 409) setError(COPY_LOGOUT_BLOCKED) else setError(e.serverMessage)
+                } catch (_: AgentError.Timeout) {
+                    // The local identity is destroyed unconditionally, so this is not a failure —
+                    // but we never saw the body, so we cannot claim the node key was invalidated.
+                    showMessage(COPY_LOGOUT_AMBIGUOUS, false)
+                } catch (e: Exception) {
+                    setError(e.message)
+                }
+                setOp(TailscaleOp.NONE)
+                fetchStatus()
+            } finally {
+                startPolling()
+            }
+        }
+    }
+
+    fun ackLogoutWarning() {
+        _state.value = _state.value.copy(logoutWarning = null)
+    }
+
+    fun noteCopiedToClipboard() {
+        showMessage(COPY_COPIED, false)
+    }
+
+    // MARK: - Install / update
+
+    fun openUpdateSheet() {
+        if (!_state.value.actionsEnabled) return
+        _state.value = _state.value.copy(showUpdateSheet = true)
+        fetchLatestRelease()
+    }
+
+    fun dismissUpdateSheet() {
+        _state.value = _state.value.copy(showUpdateSheet = false)
+    }
+
+    fun fetchLatestRelease() {
+        viewModelScope.launch {
+            _state.value = _state.value.copy(releaseFetching = true, releaseError = null, release = null)
+            val result = resolveLatestRelease()
+            _state.value = _state.value.copy(
+                releaseFetching = false,
+                release = result.getOrNull(),
+                releaseError = if (result.isFailure) {
+                    result.exceptionOrNull()?.message ?: COPY_RELEASE_FAILED
+                } else {
+                    null
+                },
+            )
+        }
+    }
+
+    fun update(version: String, sha256: String) {
+        if (_state.value.op != TailscaleOp.NONE) return
+        viewModelScope.launch {
+            stopPolling()
+            try {
+                dismissUpdateSheet()
+                setOp(TailscaleOp.UPDATING)
+                showMessage(COPY_UPDATE_IN_PROGRESS, false)
+                var watching: String? = version
+                try {
+                    withReauth {
+                        agentClient.postJSON(PATH_UPDATE, mapOf("version" to version, "sha256" to sha256))
+                    }
+                } catch (e: AgentError.ApiError) {
+                    // 409 means an update is already running — reconcile from status rather than
+                    // erroring. It isn't necessarily ours, so we can't cross-check the version.
+                    if (e.status == 409) {
+                        watching = null
+                    } else {
+                        setOp(TailscaleOp.NONE)
+                        setError(e.serverMessage)
+                        return@launch
+                    }
+                } catch (e: Exception) {
+                    setOp(TailscaleOp.NONE)
+                    setError(e.message)
+                    return@launch
+                }
+                watchUpdate(watching)
+            } finally {
+                startPolling()
+            }
+        }
+    }
+
+    private suspend fun watchUpdate(requestedVersion: String?) {
+        repeat(UPDATE_CAP_POLLS) {
+            delay(POLL_ACTIVE_MS)
+            fetchStatus()
+            if (!_state.value.status.updating) {
+                setOp(TailscaleOp.NONE)
+                reportUpdateOutcome(requestedVersion)
+                return
+            }
+        }
+        // Still updating at the cap: not a failure. Drop the local op so status.updating alone
+        // holds the phase, and let a later entry pick the watch back up.
+        setOp(TailscaleOp.NONE)
+    }
+
+    private fun reportUpdateOutcome(requestedVersion: String?) {
+        val status = _state.value.status
+        val last = status.lastUpdate
+        when {
+            // last_update is in-memory only, so an agent restart during the update erases it.
+            last == null -> showMessage(COPY_UPDATE_UNKNOWN, true)
+            !last.ok -> showMessage("Update failed: ${last.error ?: "unknown error"}", true)
+            requestedVersion != null && status.pinnedVersion != requestedVersion ->
+                showMessage(COPY_UPDATE_VERSION_UNCHANGED, true)
+            else -> showMessage("Updated to ${last.version}.", false)
+        }
+    }
+
+    private suspend fun resolveLatestRelease(): Result<TailscaleRelease> = withContext(Dispatchers.IO) {
+        val indexBody = try {
+            httpGetText(RELEASE_INDEX_URL)
+        } catch (_: Exception) {
+            return@withContext Result.failure(ReleaseLookupException(COPY_RELEASE_FAILED))
+        }
+        val index = runCatching { Json.parseToJsonElement(indexBody) as? JsonObject }.getOrNull()
+            ?: return@withContext Result.failure(ReleaseLookupException(COPY_RELEASE_FAILED))
+
+        // The device is aarch64 and the agent's download URL hardcodes arm64 — any other arch
+        // would download a tarball whose checksum can never match.
+        val arm64 = (index["Tarballs"] as? JsonObject)?.get("arm64").asJsonString().orEmpty()
+        if (arm64.isBlank()) {
+            return@withContext Result.failure(ReleaseLookupException(COPY_RELEASE_NO_ARM64))
+        }
+        val version = index["TarballsVersion"].asJsonString()?.trim().orEmpty()
+        if (TailscaleValidator.version(version) != null) {
+            return@withContext Result.failure(ReleaseLookupException(COPY_RELEASE_FAILED))
+        }
+
+        val shaBody = try {
+            httpGetText("$RELEASE_BASE/tailscale_${version}_arm64.tgz.sha256")
+        } catch (_: Exception) {
+            return@withContext Result.failure(ReleaseLookupException(COPY_RELEASE_FAILED))
+        }
+        // Today the body is a bare hash, but "<hash>  <filename>" is the usual sidecar shape.
+        val sha = shaBody.trim().split(Regex("\\s+")).firstOrNull().orEmpty().lowercase()
+        if (TailscaleValidator.sha256(sha) != null) {
+            return@withContext Result.failure(ReleaseLookupException(COPY_RELEASE_BAD_SHA))
+        }
+        Result.success(TailscaleRelease(version = version, sha256 = sha))
+    }
+
+    /** No Authorization header, HTTPS only — this call leaves the router's trust boundary. */
+    private fun httpGetText(url: String): String {
+        val request = Request.Builder().url(url).get().build()
+        releaseClient.newCall(request).execute().use { response ->
+            if (!response.isSuccessful) throw ReleaseLookupException("HTTP ${response.code}")
+            return response.body?.string() ?: throw ReleaseLookupException("empty body")
+        }
+    }
+
+    // MARK: - Polling
+
+    private fun startPolling() {
+        pollingJob?.cancel()
+        pollingJob = viewModelScope.launch {
+            while (isActive) {
+                delay(pollIntervalMs())
+                fetchStatus()
+            }
+        }
+    }
+
+    private fun stopPolling() {
+        pollingJob?.cancel()
+        pollingJob = null
+    }
+
+    private fun pollIntervalMs(): Long {
+        val s = _state.value
+        if (s.op != TailscaleOp.NONE) return POLL_ACTIVE_MS
+        return when (s.phase) {
+            TailscalePhase.UPDATING,
+            TailscalePhase.STARTING,
+            TailscalePhase.PAUSED,
+            TailscalePhase.TURNING_OFF,
+            TailscalePhase.LOGGING_OUT,
+            TailscalePhase.ENROLLING,
+            TailscalePhase.VERIFYING_ENROLLMENT,
+            TailscalePhase.AWAITING_BROWSER_LOGIN,
+            TailscalePhase.PENDING_APPROVAL,
+            TailscalePhase.DEGRADED,
+            TailscalePhase.UNKNOWN,
+            -> POLL_ACTIVE_MS
+            else -> POLL_IDLE_MS
+        }
+    }
+
+    /** Bounded: `state` can legitimately sit in connecting/starting forever. */
+    private suspend fun awaitStatus(maxPolls: Int, predicate: (TailscaleStatus) -> Boolean): Boolean {
+        repeat(maxPolls) {
+            delay(POLL_ACTIVE_MS)
+            fetchStatus()
+            if (predicate(_state.value.status)) return true
+            if (pollFailures >= MAX_POLL_FAILURES) return false
+        }
+        return false
+    }
+
+    /**
+     * The poll loop stays silent on failure — the circuit breaker speaks for it, and a screen that
+     * times out by design would otherwise flash errors. Only refresh() reports: that copy is the
+     * refresh surface, and every op cap carries its own copy already guarded by `connectionLost`.
+     */
+    private suspend fun fetchStatus(reportFailure: Boolean = false): Boolean =
+        try {
+            adoptStatus(TailscaleParser.parse(withReauth { agentClient.getJSON(PATH_STATUS) }))
+            pollFailures = 0
+            true
+        } catch (e: CancellationException) {
+            // Cancelling the poll loop must not read as a router failure.
+            throw e
+        } catch (e: Exception) {
+            pollFailures++
+            if (pollFailures >= MAX_POLL_FAILURES) {
+                stopPolling()
+                showMessage(COPY_LOST_CONNECTION, true)
+            } else if (reportFailure) {
+                setError("Failed to load Tailscale status: ${e.message}")
+            }
+            false
+        }
+
+    /**
+     * Bearer tokens expire after an hour and this screen long-polls across that boundary. A 401 is
+     * rejected by the agent's auth middleware before any handler runs, so replaying the call —
+     * including /setup — cannot have consumed an auth key. Guarded so an endpoint that keeps
+     * returning 401 can't loop while reauth keeps succeeding.
+     */
+    private suspend fun <T> withReauth(block: suspend () -> T): T =
+        try {
+            block().also { reauthAttempted = false }
+        } catch (e: AgentError.Unauthorized) {
+            if (reauthAttempted || !authManager.reauthenticate()) throw e
+            reauthAttempted = true
+            block().also { reauthAttempted = false }
+        }
+
+    // MARK: - State plumbing
+
+    private fun adoptStatus(status: TailscaleStatus) {
+        val s = _state.value
+        var next = s.copy(
+            status = status,
+            degradedPolls = if (status.state == "degraded") s.degradedPolls + 1 else 0,
+            isRemoteSession = computeRemoteSession(status),
+        )
+        // Seed the edit buffers once. Re-seeding from a poll would erase the user's typing.
+        if (!s.initialLoadDone) {
+            next = next.copy(
+                initialLoadDone = true,
+                editHostname = status.hostname,
+                editRoutes = status.advertiseRoutes.joinToString(", "),
+                editSsh = status.tailscaleSsh,
+                editWakelock = status.holdWakelock,
+            )
+        }
+        _state.value = next
+    }
+
+    private fun adoptLoginUrl(url: String) {
+        _state.value = _state.value.copy(status = _state.value.status.copy(loginUrl = url))
+    }
+
+    private fun seedBuffers(status: TailscaleStatus) {
+        _state.value = _state.value.copy(
+            editHostname = status.hostname,
+            editRoutes = status.advertiseRoutes.joinToString(", "),
+            editSsh = status.tailscaleSsh,
+            editWakelock = status.holdWakelock,
+            hostnameError = null,
+            routesError = null,
+        )
+    }
+
+    /**
+     * Heuristic and it fails open: it can't see a tailnet-side proxy, a custom DNS alias, or a
+     * subnet route to the LAN address through the tunnel. It supplements the always-on wording in
+     * the destructive confirms, never replaces it.
+     */
+    private fun computeRemoteSession(status: TailscaleStatus): Boolean {
+        val host = runCatching { URI(agentClient.baseURL).host }.getOrNull() ?: return false
+        if (status.tailscaleIps.any { it == host }) return true
+        if (status.displayDnsName?.equals(host, ignoreCase = true) == true) return true
+        val octets = host.split('.')
+        val nums = octets.mapNotNull { part -> part.toIntOrNull()?.takeIf { it in 0..255 } }
+        // 100.64.0.0/10 — the CGNAT range tailnet addresses are drawn from.
+        return octets.size == 4 && nums.size == 4 && nums[0] == 100 && nums[1] in 64..127
+    }
+
+    private suspend fun handleEnablePathError(e: AgentError.ApiError) {
+        when (e.status) {
+            403 -> blockPasswordGate(e.serverMessage)
+            // The same "update in progress" condition is a 409 on setup/login-url/logout but a
+            // 500 here, so a 500 from /enable must not be read as permanent.
+            500 -> {
+                fetchStatus()
+                if (_state.value.status.updating) showMessage(COPY_UPDATE_IN_PROGRESS, false)
+                else setError(e.serverMessage)
+            }
+            else -> setError(e.serverMessage)
+        }
+    }
+
+    private fun blockPasswordGate(serverMessage: String) {
+        _state.value = _state.value.copy(passwordGateMessage = serverMessage, message = null)
+    }
+
+    private fun clearPasswordGate() {
+        _state.value = _state.value.copy(passwordGateMessage = null)
+    }
+
+    private fun setOp(op: TailscaleOp) {
+        _state.value = _state.value.copy(op = op)
+    }
+
+    private fun showMessage(text: String?, isError: Boolean) {
+        _state.value = _state.value.copy(message = text, messageIsError = isError)
+    }
+
+    private fun setError(msg: String?) {
+        _state.value = _state.value.copy(
+            isLoading = false,
+            message = msg ?: "Unknown error",
+            messageIsError = true,
+        )
+    }
+}
+
+private class ReleaseLookupException(message: String) : Exception(message)
+
+private fun JsonElement?.asJsonString(): String? = (this as? JsonPrimitive)?.contentOrNull

--- a/mobile/android/OpenU60/app/src/main/java/com/openu60/navigation/AppNavigation.kt
+++ b/mobile/android/OpenU60/app/src/main/java/com/openu60/navigation/AppNavigation.kt
@@ -37,6 +37,7 @@ import com.openu60.feature.router.stk.STKScreen
 import com.openu60.feature.router.qos.QoSScreen
 import com.openu60.feature.router.telemetry.TelemetryBlockerScreen
 import com.openu60.feature.router.vpn.VPNPassthroughScreen
+import com.openu60.feature.router.tailscale.TailscaleScreen
 import com.openu60.feature.router.dns.DNSSettingsScreen
 import com.openu60.feature.router.dns.DoHCacheInspectorScreen
 import com.openu60.feature.router.wifi.GuestWiFiSettingsScreen
@@ -116,6 +117,7 @@ sealed class Screen(val route: String) {
     data object SignalDetect : Screen("router/signal_detect")
     data object ScheduleReboot : Screen("router/schedule_reboot")
     data object DoHCache : Screen("router/doh_cache")
+    data object Tailscale : Screen("router/tailscale")
 
     // SMS Forwarding
     data object SMSForwardConfig : Screen("sms/forward/config")
@@ -216,6 +218,7 @@ fun AppNavigation() {
                     onNavigateToFirewall = { navController.navigate(Screen.Firewall.route) },
                     onNavigateToTelemetryBlocker = { navController.navigate(Screen.TelemetryBlocker.route) },
                     onNavigateToVPNPassthrough = { navController.navigate(Screen.VPNPassthrough.route) },
+                    onNavigateToTailscale = { navController.navigate(Screen.Tailscale.route) },
                     onNavigateToQoS = { navController.navigate(Screen.QoS.route) },
                     onNavigateToDeviceControl = { navController.navigate(Screen.DeviceControl.route) },
                     onNavigateToScheduleReboot = { navController.navigate(Screen.ScheduleReboot.route) },
@@ -347,6 +350,9 @@ fun AppNavigation() {
             }
             composable(Screen.VPNPassthrough.route) {
                 VPNPassthroughScreen(onBack = { navController.popBackStack() })
+            }
+            composable(Screen.Tailscale.route) {
+                TailscaleScreen(onBack = { navController.popBackStack() })
             }
             composable(Screen.QoS.route) {
                 QoSScreen(onBack = { navController.popBackStack() })

--- a/mobile/ios/OpenU60/Core/Networking/AgentClient.swift
+++ b/mobile/ios/OpenU60/Core/Networking/AgentClient.swift
@@ -8,12 +8,24 @@ final class AgentClient {
     var token: String?
 
     private let session: URLSession
+    private let slowSession: URLSession
 
     init(baseURL: String = "http://192.168.0.1:9090") {
         let config = URLSessionConfiguration.default
         config.timeoutIntervalForRequest = 10
         config.timeoutIntervalForResource = 15
         self.session = URLSession(configuration: config)
+
+        // For endpoints that legitimately block for minutes (tailscale setup /
+        // logout / config / disable). A separate session is mandatory:
+        // timeoutIntervalForResource is a session-level total-load cap that
+        // URLRequest.timeoutInterval cannot override, and raising it on the
+        // shared session would let a slow response hang every other screen.
+        let slowConfig = URLSessionConfiguration.default
+        slowConfig.timeoutIntervalForRequest = 240
+        slowConfig.timeoutIntervalForResource = 300
+        self.slowSession = URLSession(configuration: slowConfig)
+
         self.baseURL = baseURL
     }
 
@@ -89,6 +101,33 @@ final class AgentClient {
         return json["data"] as? [String: Any] ?? [:]
     }
 
+    /// POST with a raw dict body on the long-timeout session. For endpoints that
+    /// legitimately block for minutes.
+    func postJSONSlow(_ path: String, body: [String: Any] = [:]) async throws -> [String: Any] {
+        let bodyData = try JSONSerialization.data(withJSONObject: body)
+        let data = try await request(method: "POST", path: path, body: bodyData, slow: true)
+        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw AgentError.decodingError("Expected JSON object")
+        }
+        guard let ok = json["ok"] as? Bool, ok else {
+            throw AgentError.serverError(json["error"] as? String ?? "Unknown error")
+        }
+        return json["data"] as? [String: Any] ?? [:]
+    }
+
+    /// PUT with a raw dict body on the long-timeout session.
+    func putJSONSlow(_ path: String, body: [String: Any] = [:]) async throws -> [String: Any] {
+        let bodyData = try JSONSerialization.data(withJSONObject: body)
+        let data = try await request(method: "PUT", path: path, body: bodyData, slow: true)
+        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw AgentError.decodingError("Expected JSON object")
+        }
+        guard let ok = json["ok"] as? Bool, ok else {
+            throw AgentError.serverError(json["error"] as? String ?? "Unknown error")
+        }
+        return json["data"] as? [String: Any] ?? [:]
+    }
+
     /// DELETE with a raw dict body and return the `data` field as a raw dictionary.
     func deleteJSON(_ path: String, body: [String: Any] = [:]) async throws -> [String: Any] {
         let bodyData = try JSONSerialization.data(withJSONObject: body)
@@ -141,7 +180,7 @@ final class AgentClient {
 
     // MARK: - Internal
 
-    private func request(method: String, path: String, body: Data?, authenticated: Bool = true) async throws -> Data {
+    private func request(method: String, path: String, body: Data?, authenticated: Bool = true, slow: Bool = false) async throws -> Data {
         guard let url = URL(string: baseURL + path) else {
             throw AgentError.serverUnreachable
         }
@@ -160,7 +199,7 @@ final class AgentClient {
         let data: Data
         let response: URLResponse
         do {
-            (data, response) = try await session.data(for: req)
+            (data, response) = try await (slow ? slowSession : session).data(for: req)
         } catch let error as URLError where error.code == .timedOut {
             throw AgentError.timeout
         } catch let error as URLError where error.code == .cannotConnectToHost || error.code == .notConnectedToInternet {
@@ -179,8 +218,14 @@ final class AgentClient {
         case 401:
             throw AgentError.unauthorized
         default:
-            let message = String(data: data, encoding: .utf8) ?? "HTTP \(httpResponse.statusCode)"
-            throw AgentError.serverError(message)
+            // Lift the envelope's error so callers get a clean message AND the
+            // status code. Falls back to the raw body.
+            if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+               let message = json["error"] as? String, !message.isEmpty {
+                throw AgentError.apiError(status: httpResponse.statusCode, message: message)
+            }
+            let raw = String(data: data, encoding: .utf8) ?? "HTTP \(httpResponse.statusCode)"
+            throw AgentError.apiError(status: httpResponse.statusCode, message: raw)
         }
     }
 

--- a/mobile/ios/OpenU60/Core/Networking/AgentError.swift
+++ b/mobile/ios/OpenU60/Core/Networking/AgentError.swift
@@ -2,6 +2,10 @@ import Foundation
 
 enum AgentError: LocalizedError {
     case unauthorized
+    /// A non-2xx, non-401 response. Carries the status so callers can branch on
+    /// it — the agent uses distinct codes for conditions its strings do not
+    /// reliably distinguish.
+    case apiError(status: Int, message: String)
     case serverError(String)
     case networkError(Error)
     case decodingError(String)
@@ -12,6 +16,8 @@ enum AgentError: LocalizedError {
         switch self {
         case .unauthorized:
             return "Not authenticated. Please log in."
+        case .apiError(_, let message):
+            return message
         case .serverError(let message):
             return "Server error: \(message)"
         case .networkError(let error):

--- a/mobile/ios/OpenU60/Features/RouterSettings/RouterSettingsListView.swift
+++ b/mobile/ios/OpenU60/Features/RouterSettings/RouterSettingsListView.swift
@@ -102,6 +102,11 @@ struct RouterSettingsListView: View {
                         Label("VPN Passthrough", systemImage: "lock.shield")
                     }
 
+                    NavigationLink {
+                        TailscaleView(viewModel: TailscaleViewModel(client: client, authManager: authManager))
+                    } label: {
+                        Label("Tailscale", systemImage: "network.badge.shield.half.filled")
+                    }
                 }
 
                 Section("Quality") {

--- a/mobile/ios/OpenU60/Features/RouterSettings/Tailscale/TailscaleModels.swift
+++ b/mobile/ios/OpenU60/Features/RouterSettings/Tailscale/TailscaleModels.swift
@@ -1,0 +1,297 @@
+import Foundation
+
+// MARK: - Status
+
+struct TailscaleLastUpdate: Equatable {
+    var version: String
+    var ok: Bool
+    var error: String?
+    var finishedAt: Int
+}
+
+struct TailscaleStatus: Equatable {
+    var installed: Bool
+    var enabled: Bool
+    var enrolled: Bool
+    var daemonRunning: Bool
+    var state: String
+    var backendState: String?
+    var health: [String]
+    var tailscaleIPs: [String]
+    var dnsName: String?
+    var relay: String?
+    var direct: Bool
+    var keyExpiry: String?
+    var expired: Bool
+    var clientVersion: String?
+    var loginURL: String?
+    var wakelockHeld: Bool
+    var updating: Bool
+    var lastUpdate: TailscaleLastUpdate?
+    var hostname: String
+    var advertiseRoutes: [String]
+    var tailscaleSSH: Bool
+    var holdWakelock: Bool
+    var pinnedVersion: String
+    /// The key is absent from the payload except when `state == "starting"`.
+    var error: String?
+
+    static let empty = TailscaleStatus(
+        installed: false, enabled: false, enrolled: false, daemonRunning: false,
+        state: "unknown", backendState: nil, health: [], tailscaleIPs: [],
+        dnsName: nil, relay: nil, direct: false, keyExpiry: nil, expired: false,
+        clientVersion: nil, loginURL: nil, wakelockHeld: false, updating: false,
+        lastUpdate: nil, hostname: "u60-pro", advertiseRoutes: [],
+        tailscaleSSH: false, holdWakelock: true, pinnedVersion: "", error: nil
+    )
+
+    /// dns_name without the trailing dot.
+    var displayDNSName: String? {
+        guard let dnsName, !dnsName.isEmpty else { return nil }
+        return dnsName.hasSuffix(".") ? String(dnsName.dropLast()) : dnsName
+    }
+
+    /// First tailnet address (the one users copy).
+    var primaryIP: String? { tailscaleIPs.first }
+
+    /// Relayed is EXPECTED behind CGNAT-to-CGNAT — render neutrally.
+    var pathDescription: String {
+        if direct { return "Direct" }
+        if let relay, !relay.isEmpty { return "Via relay (\(relay))" }
+        return "Via relay"
+    }
+
+    /// hold_wakelock is intent; wakelock_held is reality.
+    var wakelockFailing: Bool { enabled && holdWakelock && !wakelockHeld }
+
+    /// A version swap that did not take effect.
+    var versionMismatch: Bool {
+        guard !pinnedVersion.isEmpty, let clientVersion, !clientVersion.isEmpty else { return false }
+        return pinnedVersion != clientVersion
+    }
+
+    /// key_expiry is RFC3339. A null key_expiry means expiry is disabled, which
+    /// is the good outcome — it has no date and must never render as "unknown".
+    var keyExpiryDate: Date? {
+        guard let keyExpiry, !keyExpiry.isEmpty else { return nil }
+        return RFC3339.fractional.date(from: keyExpiry) ?? RFC3339.plain.date(from: keyExpiry)
+    }
+
+    var displayKeyExpiry: String {
+        guard let keyExpiry, !keyExpiry.isEmpty else { return "Never" }
+        guard let date = keyExpiryDate else { return keyExpiry }
+        return date.formatted(date: .abbreviated, time: .shortened)
+    }
+
+    /// Null unless the key expires within 14 days — an expiry already in the past
+    /// belongs to the "Node key expired" card, and a null one means "never".
+    /// The count is a seconds-based ceiling because Android computes it that way:
+    /// the two platforms must name the same N in "expires in N days".
+    var daysUntilKeyExpiry: Int? {
+        guard let date = keyExpiryDate else { return nil }
+        let seconds = date.timeIntervalSinceNow
+        guard seconds >= 1, seconds < 14 * 86_400 else { return nil }
+        return (Int(seconds) + 86_399) / 86_400
+    }
+}
+
+private enum RFC3339 {
+    static let fractional: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter
+    }()
+    static let plain = ISO8601DateFormatter()
+}
+
+// MARK: - Parsing
+
+enum TailscaleParser {
+    /// Total: never throws, never returns nil, defaults every field.
+    static func parse(_ data: [String: Any]) -> TailscaleStatus {
+        TailscaleStatus(
+            installed: data["installed"] as? Bool ?? false,
+            enabled: data["enabled"] as? Bool ?? false,
+            enrolled: data["enrolled"] as? Bool ?? false,
+            daemonRunning: data["daemon_running"] as? Bool ?? false,
+            state: data["state"] as? String ?? "unknown",
+            backendState: data["backend_state"] as? String,
+            health: data["health"] as? [String] ?? [],
+            // tailscale_ips can be NULL (not just []) when unenrolled.
+            tailscaleIPs: data["tailscale_ips"] as? [String] ?? [],
+            dnsName: data["dns_name"] as? String,
+            relay: data["relay"] as? String,
+            direct: data["direct"] as? Bool ?? false,
+            keyExpiry: data["key_expiry"] as? String,
+            expired: data["expired"] as? Bool ?? false,
+            clientVersion: data["client_version"] as? String,
+            loginURL: data["login_url"] as? String,
+            wakelockHeld: data["wakelock_held"] as? Bool ?? false,
+            updating: data["updating"] as? Bool ?? false,
+            lastUpdate: parseLastUpdate(data["last_update"] as? [String: Any]),
+            hostname: data["hostname"] as? String ?? "u60-pro",
+            advertiseRoutes: data["advertise_routes"] as? [String] ?? [],
+            tailscaleSSH: data["tailscale_ssh"] as? Bool ?? false,
+            holdWakelock: data["hold_wakelock"] as? Bool ?? true,
+            pinnedVersion: data["pinned_version"] as? String ?? "",
+            error: data["error"] as? String
+        )
+    }
+
+    static func parseLastUpdate(_ data: [String: Any]?) -> TailscaleLastUpdate? {
+        guard let data else { return nil }
+        return TailscaleLastUpdate(
+            version: data["version"] as? String ?? "",
+            ok: data["ok"] as? Bool ?? false,
+            error: data["error"] as? String,
+            finishedAt: data["finished_at"] as? Int ?? 0
+        )
+    }
+}
+
+// MARK: - Validation
+
+/// Mirrors the agent's own rules so a bad field is caught before the round trip.
+/// The server stays authoritative — these only pre-empt.
+enum TailscaleValidator {
+    /// Mirrors `TsConfig::apply_patch`, config.rs:57-62.
+    static func hostname(_ raw: String) -> String? {
+        let value = raw.trimmingCharacters(in: .whitespaces)
+        guard !value.isEmpty, value.count <= 63,
+              value.allSatisfy({ $0.isASCII && ($0.isLetter || $0.isNumber || $0 == "-") }) else {
+            return "Use 1-63 letters, numbers or hyphens."
+        }
+        return nil
+    }
+
+    /// Mirrors `valid_cidr`, config.rs:83-93 — IPv4 only, even though the
+    /// tailnet itself supports IPv6.
+    static func routes(_ raw: String) -> String? {
+        for entry in parseRoutes(raw) where !isValidCIDR(entry) {
+            return "Only IPv4 routes like 192.168.0.0/24 are supported."
+        }
+        return nil
+    }
+
+    /// Comma-separated field ⇄ array. An empty field yields `[]`, which clears
+    /// the advertised routes — a real capability, not an error.
+    static func parseRoutes(_ raw: String) -> [String] {
+        raw.split(separator: ",")
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+    }
+
+    /// Mirrors mod.rs:1116.
+    static func version(_ raw: String) -> String? {
+        let value = raw.trimmingCharacters(in: .whitespaces)
+        guard !value.isEmpty, value.allSatisfy({ $0.isASCII && ($0.isNumber || $0 == ".") }) else {
+            return "Use digits and dots only, like 1.98.9."
+        }
+        return nil
+    }
+
+    /// Mirrors mod.rs:1120. The agent lowercases server-side, so accept either case.
+    static func sha256(_ raw: String) -> String? {
+        let value = raw.trimmingCharacters(in: .whitespaces)
+        guard value.count == 64, value.allSatisfy({ $0.isASCII && $0.isHexDigit }) else {
+            return "Must be exactly 64 hexadecimal characters."
+        }
+        return nil
+    }
+
+    /// `valid_cidr` does not require host bits to be zero, so `192.168.0.5/24`
+    /// is accepted server-side. Do not be stricter than the server.
+    private static func isValidCIDR(_ entry: String) -> Bool {
+        let parts = entry.split(separator: "/", maxSplits: 1, omittingEmptySubsequences: false)
+        guard parts.count == 2, let prefix = UInt8(parts[1]), prefix <= 32 else { return false }
+        let octets = parts[0].split(separator: ".", omittingEmptySubsequences: false)
+        return octets.count == 4 && octets.allSatisfy { UInt8($0) != nil }
+    }
+}
+
+// MARK: - Release lookup
+
+enum TailscaleReleaseError: LocalizedError {
+    case fetchFailed
+    case noARM64
+    case badSHA
+
+    var errorDescription: String? {
+        switch self {
+        case .fetchFailed:
+            return "Couldn't reach pkgs.tailscale.com to look up the latest release. Check this phone's internet connection, or enter a version and checksum manually under Advanced."
+        case .noARM64:
+            return "The latest Tailscale release doesn't publish an arm64 build, which this router needs. Enter a version and checksum manually under Advanced."
+        case .badSHA:
+            return "pkgs.tailscale.com returned a checksum this app couldn't read. Enter a version and checksum manually under Advanced."
+        }
+    }
+}
+
+/// Resolves the current stable release straight from pkgs.tailscale.com.
+///
+/// Deliberately not routed through `AgentClient`: that client is pinned to the
+/// router's base URL and attaches the agent bearer token, which must never
+/// leave the LAN. A failure here is the phone's internet, never the agent.
+enum TailscaleReleaseFetcher {
+    /// The device is aarch64 and the agent's download URL hardcodes arm64
+    /// (mod.rs:1175). The two MUST agree or the sha256 can never match.
+    private static let arch = "arm64"
+    private static let indexURL = "https://pkgs.tailscale.com/stable/?mode=json"
+
+    static func resolveLatest() async throws -> (version: String, sha256: String) {
+        let config = URLSessionConfiguration.ephemeral
+        config.timeoutIntervalForRequest = 20
+        config.timeoutIntervalForResource = 20
+        let session = URLSession(configuration: config)
+        defer { session.invalidateAndCancel() }
+
+        let indexData = try await fetch(indexURL, on: session, failure: .fetchFailed)
+        guard let index = try? JSONSerialization.jsonObject(with: indexData) as? [String: Any] else {
+            throw TailscaleReleaseError.fetchFailed
+        }
+        guard let tarballs = index["Tarballs"] as? [String: Any],
+              let tarball = tarballs[arch] as? String, !tarball.isEmpty else {
+            throw TailscaleReleaseError.noARM64
+        }
+        // A version the agent would reject is a lookup failure, not a 400 to
+        // discover server-side.
+        guard let version = index["TarballsVersion"] as? String,
+              TailscaleValidator.version(version) == nil else {
+            throw TailscaleReleaseError.fetchFailed
+        }
+
+        let shaURL = "https://pkgs.tailscale.com/stable/tailscale_\(version)_\(arch).tgz.sha256"
+        // A sidecar that never arrives is a reachability failure, not a checksum
+        // we couldn't read — .badSHA is only for a body we did receive.
+        let shaData = try await fetch(shaURL, on: session, failure: .fetchFailed)
+        // Today the body is a bare hash, but `<hash>  <filename>` is the common
+        // sidecar shape and must not break us.
+        guard let body = String(data: shaData, encoding: .utf8),
+              let first = body.split(whereSeparator: { $0.isWhitespace }).first else {
+            throw TailscaleReleaseError.badSHA
+        }
+        let sha256 = first.lowercased()
+        guard TailscaleValidator.sha256(sha256) == nil else { throw TailscaleReleaseError.badSHA }
+        return (version, sha256)
+    }
+
+    private static func fetch(
+        _ urlString: String,
+        on session: URLSession,
+        failure: TailscaleReleaseError
+    ) async throws -> Data {
+        guard let url = URL(string: urlString), url.scheme == "https" else { throw failure }
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await session.data(from: url)
+        } catch {
+            throw failure
+        }
+        guard let http = response as? HTTPURLResponse, (200...299).contains(http.statusCode) else {
+            throw failure
+        }
+        return data
+    }
+}

--- a/mobile/ios/OpenU60/Features/RouterSettings/Tailscale/TailscaleView.swift
+++ b/mobile/ios/OpenU60/Features/RouterSettings/Tailscale/TailscaleView.swift
@@ -1,0 +1,665 @@
+import SwiftUI
+
+private let tailscaleAdminURL = URL(string: "https://login.tailscale.com/admin/machines")!
+private let tailscaleKeysURL = URL(string: "https://login.tailscale.com/admin/settings/keys")!
+
+private let remoteSessionParagraph = "You're connected to this router over Tailscale right now. This will drop your connection immediately, and you won't be able to reconnect remotely. Continue only if you have local network or physical access to the router."
+
+struct TailscaleView: View {
+    @Bindable var viewModel: TailscaleViewModel
+    @Environment(\.openURL) private var openURL
+
+    var body: some View {
+        List {
+            if let msg = viewModel.message {
+                Section {
+                    Text(msg)
+                        .font(.subheadline)
+                        .foregroundStyle(viewModel.messageIsError ? .red : .green)
+                        .textSelection(.enabled)
+                }
+            }
+
+            alertSections
+            statusSection
+
+            if viewModel.phase == .healthy || viewModel.phase == .degraded {
+                connectionDetailsSection
+                advisoriesSection
+            }
+
+            if viewModel.status.enrolled, viewModel.phase != .updating, viewModel.phase != .notInstalled {
+                settingsSection
+            }
+
+            if viewModel.phase != .updating {
+                maintenanceSection
+            }
+
+            if viewModel.status.enrolled {
+                dangerZoneSection
+            }
+        }
+        .navigationTitle("Tailscale")
+        .refreshable { await viewModel.refresh() }
+        .overlay {
+            if viewModel.isLoading {
+                ProgressView()
+                    .padding()
+                    .background(Color(.systemBackground).opacity(0.85), in: RoundedRectangle(cornerRadius: 8))
+            }
+        }
+        .task { await viewModel.refresh() }
+        .sheet(isPresented: $viewModel.showEnrollSheet, onDismiss: { viewModel.authKeyInput = "" }) {
+            TailscaleEnrollSheet(viewModel: viewModel)
+        }
+        // Advanced input is sheet-scoped but lives on the VM, and it outranks the
+        // fetched release — a cancelled edit would silently pin the next update to
+        // a version the re-opened (collapsed) disclosure no longer shows.
+        .sheet(isPresented: $viewModel.showUpdateSheet, onDismiss: {
+            viewModel.advancedVersion = ""
+            viewModel.advancedSHA256 = ""
+        }) {
+            TailscaleUpdateSheet(viewModel: viewModel)
+        }
+        .sheet(isPresented: $viewModel.showLogoutPasswordConfirm) {
+            PasswordConfirmView(
+                title: "Log out of Tailscale?",
+                message: logoutMessage,
+                confirmLabel: "Log Out"
+            ) {
+                await viewModel.logout()
+            }
+        }
+        .alert("Turn off remote access?", isPresented: $viewModel.showDisableConfirm) {
+            Button("Cancel", role: .cancel) {}
+            Button("Turn Off", role: .destructive) { Task { await viewModel.disable() } }
+        } message: {
+            Text(disableMessage)
+        }
+        .alert(
+            viewModel.pendingConfigConfirm?.title ?? "",
+            isPresented: $viewModel.showConfigConfirm,
+            presenting: viewModel.pendingConfigConfirm
+        ) { confirm in
+            Button("Cancel", role: .cancel) { viewModel.cancelPendingConfig() }
+            Button(confirm.confirmLabel) { Task { await viewModel.confirmPendingConfig() } }
+        } message: { confirm in
+            Text(confirm.message)
+        }
+    }
+
+    // MARK: - Blocking alerts
+
+    @ViewBuilder
+    private var alertSections: some View {
+        if viewModel.passwordGateBlocked {
+            Section {
+                TailscaleAlert(title: "Remote access needs an agent password", severity: .critical) {
+                    Text("This router's agent has no password, so its API is open to anyone who can reach it. Turning on Tailscale would expose the router's full management API to every device on your tailnet — over the tunnel every request arrives from 127.0.0.1 with no peer identity, so the agent can't tell your laptop from anyone else's.\n\nSet ZTE_AGENT_PASSWORD on the router and restart the agent, then come back.")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                    if let detail = viewModel.passwordGateMessage {
+                        Text(detail)
+                            .font(.caption.monospaced())
+                            .foregroundStyle(.secondary)
+                            .textSelection(.enabled)
+                    }
+                }
+            }
+        }
+
+        if let warning = viewModel.logoutWarning {
+            Section {
+                TailscaleAlert(title: "Logged out, but this router's key was NOT invalidated:", severity: .critical) {
+                    Text(warning)
+                        .font(.caption.monospaced())
+                        .textSelection(.enabled)
+                    Text("It may still be a live machine on your tailnet. Remove it in the admin console.")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+                Button("Open Admin Console") { openURL(tailscaleAdminURL) }
+                Button("I've removed it") { viewModel.dismissLogoutWarning() }
+            }
+        }
+
+        if viewModel.status.wakelockFailing {
+            Section {
+                TailscaleAlert(title: "The router may go to sleep", severity: .warning) {
+                    Text("\"Keep router awake\" is on, but the router refused the wakelock. It may sleep and become unreachable even though it looks connected.")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+
+        if viewModel.status.expired {
+            Section {
+                TailscaleAlert(title: "Node key expired", severity: .critical) {
+                    Text("Remote access is down until you sign in again.")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+
+        if let days = viewModel.status.daysUntilKeyExpiry {
+            Section {
+                TailscaleAlert(title: "This router's key expires in \(days) days", severity: .warning) {
+                    Text("When it expires, remote access stops and can only be restored from the local network. Disable key expiry for this machine in your Tailscale admin console.")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+                Button("Open Admin Console") { openURL(tailscaleAdminURL) }
+            }
+        }
+
+        if viewModel.isRemoteSession {
+            Section {
+                TailscaleAlert(title: "You're managing this router over Tailscale", severity: .warning) {
+                    Text("Turning off, logging out, or updating will drop this connection.")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+    }
+
+    // MARK: - Status
+
+    @ViewBuilder
+    private var statusSection: some View {
+        Section {
+            VStack(alignment: .leading, spacing: 6) {
+                HStack(spacing: 8) {
+                    Text(viewModel.phase.label)
+                        .font(.headline)
+                        .foregroundStyle(viewModel.phase.severity.color)
+                    if viewModel.phase.showsSpinner {
+                        ProgressView().controlSize(.small)
+                    }
+                }
+                Text(viewModel.statusDescription)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+
+            // `error` is the one field whose key is absent everywhere else.
+            if viewModel.phase == .starting, let detail = viewModel.status.error, !detail.isEmpty {
+                DisclosureGroup("Details") {
+                    Text(detail)
+                        .font(.caption.monospaced())
+                        .textSelection(.enabled)
+                }
+            }
+
+            if viewModel.phase == .unknown {
+                detailRow("Backend", viewModel.status.backendState)
+            }
+
+            primaryActions
+        } footer: {
+            if viewModel.phase == .needsLogin {
+                Text("If this router re-registers as a new machine, delete the old entry in your Tailscale admin console.")
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var primaryActions: some View {
+        switch viewModel.phase {
+        case .notInstalled:
+            Button("Install Tailscale") { viewModel.showUpdateSheet = true }
+                .disabled(viewModel.actionsDisabled)
+        case .notSetUp, .awaitingSetup:
+            Button("Set Up Remote Access") { viewModel.showEnrollSheet = true }
+                .disabled(viewModel.enrollDisabled)
+        case .turnedOff:
+            Button("Turn On Remote Access") { Task { await viewModel.enableRemoteAccess() } }
+                .disabled(viewModel.enrollDisabled)
+        case .needsLogin:
+            Button("Sign In Again") { viewModel.showEnrollSheet = true }
+                .disabled(viewModel.enrollDisabled)
+        case .pendingApproval:
+            Button("Open Admin Console") { openURL(tailscaleAdminURL) }
+        case .awaitingBrowserLogin:
+            Button("Open Sign-In Page") {
+                if let raw = viewModel.loginURL, let url = URL(string: raw) { openURL(url) }
+            }
+            .disabled(viewModel.loginURL == nil)
+            Button("Copy Link") {
+                if let raw = viewModel.loginURL { viewModel.copyToClipboard(raw) }
+            }
+            .disabled(viewModel.loginURL == nil)
+        case .degraded:
+            if viewModel.degradedIsPersistent {
+                Button("Sign In Again") { viewModel.showEnrollSheet = true }
+                    .disabled(viewModel.enrollDisabled)
+            }
+        default:
+            EmptyView()
+        }
+    }
+
+    // MARK: - Connection details
+
+    @ViewBuilder
+    private var connectionDetailsSection: some View {
+        Section("Connection Details") {
+            detailRow("Tailscale IP", viewModel.status.primaryIP, copyable: true)
+            if viewModel.status.tailscaleIPs.count > 1 {
+                detailRow("Tailscale IPv6", viewModel.status.tailscaleIPs[1], copyable: true)
+            }
+            detailRow("MagicDNS name", viewModel.status.displayDNSName, copyable: true)
+            detailRow("Path", viewModel.status.pathDescription)
+            detailRow("Key expiry", viewModel.status.displayKeyExpiry)
+            detailRow("Version", viewModel.status.clientVersion)
+        }
+    }
+
+    @ViewBuilder
+    private var advisoriesSection: some View {
+        if !viewModel.status.health.isEmpty {
+            Section {
+                ForEach(viewModel.status.health, id: \.self) { advisory in
+                    Text(advisory)
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                        .textSelection(.enabled)
+                }
+            } header: {
+                Text("Advisories")
+            } footer: {
+                Text("These are reported by Tailscale and are often benign. They don't affect whether the router is reachable.")
+            }
+        }
+    }
+
+    // MARK: - Settings
+
+    @ViewBuilder
+    private var settingsSection: some View {
+        Section {
+            VStack(alignment: .leading, spacing: 4) {
+                TextField("Hostname", text: $viewModel.editHostname)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled()
+                if let error = viewModel.hostnameError {
+                    Text(error).font(.caption).foregroundStyle(.red)
+                }
+            }
+
+            VStack(alignment: .leading, spacing: 4) {
+                TextField("Advertise routes", text: $viewModel.editRoutes, prompt: Text("192.168.0.0/24"))
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled()
+                if let error = viewModel.routesError {
+                    Text(error).font(.caption).foregroundStyle(.red)
+                }
+            }
+
+            Toggle("Tailscale SSH", isOn: $viewModel.editSSH)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Toggle("Keep router awake", isOn: $viewModel.editWakelock)
+                Text("Keeps the router awake so it stays reachable. Turning this off lets the router sleep, and it will become unreachable even though it looks connected.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Button {
+                Task { await viewModel.applyConfig() }
+            } label: {
+                Text("Apply")
+                    .frame(maxWidth: .infinity)
+            }
+            .disabled(!viewModel.canApplyConfig)
+        } header: {
+            Text("Settings")
+        } footer: {
+            Text("This router doesn't accept DNS or subnet routes from your tailnet.")
+        }
+    }
+
+    // MARK: - Maintenance
+
+    @ViewBuilder
+    private var maintenanceSection: some View {
+        Section {
+            LabeledContent("Installed", value: viewModel.status.installed ? "Yes" : "No")
+            // "" does NOT mean not installed — it means no version this app
+            // installed is pinned.
+            LabeledContent(
+                "Pinned version",
+                value: viewModel.status.pinnedVersion.isEmpty ? "Not managed by this app" : viewModel.status.pinnedVersion
+            )
+            LabeledContent("Running version", value: viewModel.status.clientVersion ?? "--")
+
+            if viewModel.status.versionMismatch {
+                Text("Installed \(viewModel.status.pinnedVersion) but running \(viewModel.status.clientVersion ?? "--") — a version swap may not have taken effect.")
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+            }
+
+            Button(viewModel.status.installed ? "Update Tailscale" : "Install Tailscale") {
+                viewModel.showUpdateSheet = true
+            }
+            .disabled(viewModel.actionsDisabled)
+
+            if let last = viewModel.status.lastUpdate {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(last.ok ? "Updated to \(last.version)." : "Update failed: \(last.error ?? "Unknown error")")
+                        .font(.subheadline)
+                        .foregroundStyle(last.ok ? .green : .red)
+                        .textSelection(.enabled)
+                    Text(Date(timeIntervalSince1970: TimeInterval(last.finishedAt)).formatted(date: .abbreviated, time: .shortened))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        } header: {
+            Text("Maintenance")
+        } footer: {
+            Text("Update from Wi-Fi on the same network as the router. Updating restarts Tailscale and will drop a remote connection.")
+        }
+    }
+
+    // MARK: - Danger zone
+
+    @ViewBuilder
+    private var dangerZoneSection: some View {
+        Section {
+            Button("Turn Off Remote Access", role: .destructive) {
+                viewModel.showDisableConfirm = true
+            }
+            .disabled(viewModel.actionsDisabled)
+
+            Button("Log Out of Tailscale", role: .destructive) {
+                viewModel.showLogoutPasswordConfirm = true
+            }
+            .disabled(viewModel.actionsDisabled || viewModel.status.updating)
+        } header: {
+            Text("Danger Zone")
+        } footer: {
+            VStack(alignment: .leading, spacing: 4) {
+                if viewModel.phase == .healthy {
+                    Text("If you're connected over Tailscale, this will end that connection.")
+                }
+                Text("Turning off keeps this router's sign-in. Logging out deletes it.")
+            }
+        }
+    }
+
+    // MARK: - Helpers
+
+    private var disableMessage: String {
+        let body = "The router disconnects from your tailnet. Its sign-in is kept, so you can turn it back on later — but only from the local network if you lose remote access."
+        return viewModel.isRemoteSession ? "\(body)\n\n\(remoteSessionParagraph)" : body
+    }
+
+    private var logoutMessage: String {
+        let body = "This permanently deletes this router's Tailscale identity.\n\n• Remote access stops immediately.\n• Reconnecting requires a new auth key or browser sign-in.\n• This can't be undone."
+        return viewModel.isRemoteSession ? "\(body)\n\n\(remoteSessionParagraph)" : body
+    }
+
+    private func detailRow(_ label: String, _ value: String?, copyable: Bool = false) -> some View {
+        let resolved = value.flatMap { $0.isEmpty ? nil : $0 }
+        return LabeledContent(label) {
+            Text(resolved ?? "--")
+                .font(.body.monospaced())
+                .foregroundStyle(.secondary)
+        }
+        .contentShape(Rectangle())
+        .onTapGesture {
+            if copyable, let resolved { viewModel.copyToClipboard(resolved) }
+        }
+    }
+}
+
+// MARK: - Alert card
+
+private struct TailscaleAlert<Content: View>: View {
+    let title: String
+    let severity: TailscaleSeverity
+    @ViewBuilder var content: () -> Content
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(title)
+                .font(.subheadline.bold())
+                .foregroundStyle(severity.color)
+            content()
+        }
+    }
+}
+
+// MARK: - Enrollment sheet
+
+private enum TailscaleEnrollMethod: Hashable {
+    case authKey
+    case browser
+}
+
+private struct TailscaleEnrollSheet: View {
+    @Bindable var viewModel: TailscaleViewModel
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.openURL) private var openURL
+
+    @State private var method: TailscaleEnrollMethod = .authKey
+    @State private var revealKey = false
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    Text("Connect this router to your tailnet so you can reach it from anywhere.")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+
+                // The sheet covers the status card, so it has to carry the card's
+                // own progress. Tracking `op` rather than `message` is what makes
+                // it appear: pre-warm is skipped whenever the node is already
+                // enabled, leaving enrolling and verifying with no message at all.
+                if viewModel.op != .none {
+                    Section {
+                        HStack(spacing: 8) {
+                            ProgressView().controlSize(.small)
+                            Text(viewModel.phase.label)
+                                .font(.subheadline)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+
+                if let msg = viewModel.message {
+                    Section {
+                        Text(msg)
+                            .font(.subheadline)
+                            .foregroundStyle(viewModel.messageIsError ? .red : .green)
+                            .textSelection(.enabled)
+                    }
+                }
+
+                Section {
+                    Picker("Method", selection: $method) {
+                        Text("Auth key (recommended)").tag(TailscaleEnrollMethod.authKey)
+                        Text("Browser sign-in").tag(TailscaleEnrollMethod.browser)
+                    }
+                    .pickerStyle(.segmented)
+                }
+
+                if method == .authKey {
+                    authKeySections
+                } else {
+                    browserSections
+                }
+            }
+            .navigationTitle("Set Up Remote Access")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var authKeySections: some View {
+        Section {
+            Text("Create a one-off, pre-authorized key tagged tag:router in the Tailscale admin console. Tagging is what stops the key from expiring — an untagged router stops working after about 180 days and can only be fixed from the local network.")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+            Button("Open Tailscale Keys Page") { openURL(tailscaleKeysURL) }
+        }
+
+        Section("Auth key") {
+            HStack {
+                // No .textContentType — it would invite the OS to offer to save a
+                // tailnet-wide bearer credential to the keychain.
+                if revealKey {
+                    TextField("Auth key", text: $viewModel.authKeyInput, prompt: Text("tskey-auth-..."))
+                        .textInputAutocapitalization(.never)
+                        .autocorrectionDisabled()
+                } else {
+                    SecureField("Auth key", text: $viewModel.authKeyInput, prompt: Text("tskey-auth-..."))
+                        .textInputAutocapitalization(.never)
+                        .autocorrectionDisabled()
+                }
+                Button {
+                    revealKey.toggle()
+                } label: {
+                    Image(systemName: revealKey ? "eye.slash" : "eye")
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(.secondary)
+            }
+        }
+
+        Section {
+            Button {
+                Task { await viewModel.setupWithAuthKey() }
+            } label: {
+                Text("Connect")
+                    .frame(maxWidth: .infinity)
+            }
+            .disabled(viewModel.enrollDisabled || viewModel.authKeyInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+        }
+    }
+
+    @ViewBuilder
+    private var browserSections: some View {
+        Section {
+            Text("This router is added under your account, and its key will expire (default 180 days) unless you disable key expiry for it in the admin console.")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+        }
+
+        Section {
+            Button {
+                Task { await viewModel.signInWithBrowser() }
+            } label: {
+                Text("Sign In With Tailscale")
+                    .frame(maxWidth: .infinity)
+            }
+            .disabled(viewModel.enrollDisabled)
+        }
+    }
+}
+
+// MARK: - Update sheet
+
+private struct TailscaleUpdateSheet: View {
+    @Bindable var viewModel: TailscaleViewModel
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    if viewModel.releaseFetching {
+                        HStack(spacing: 8) {
+                            ProgressView().controlSize(.small)
+                            Text("Checking for the latest Tailscale release…")
+                                .font(.subheadline)
+                                .foregroundStyle(.secondary)
+                        }
+                    } else if let version = viewModel.releaseVersion {
+                        Text("Latest release: Tailscale \(version).")
+                            .font(.subheadline)
+                    } else if let error = viewModel.releaseError {
+                        Text(error)
+                            .font(.subheadline)
+                            .foregroundStyle(.red)
+                        Button("Retry") { Task { await viewModel.loadLatestRelease() } }
+                    }
+                } footer: {
+                    Text("Version and checksum come from pkgs.tailscale.com. The router verifies the download against this checksum before installing.")
+                }
+
+                Section {
+                    Text("The router downloads this over its own connection. If the router is on mobile data, this uses about 34 MB of your data plan.")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+
+                    if viewModel.isRemoteSession {
+                        Text("You're connected over Tailscale. Updating restarts the daemon and will drop this connection and any Tailscale SSH sessions. Do this from the local network.")
+                            .font(.subheadline)
+                            .foregroundStyle(.orange)
+                    }
+
+                    // The 120s "must reach Running" health gate runs only when the
+                    // node was running AND enrolled, so an unenrolled update is
+                    // never rolled back.
+                    if !viewModel.status.enrolled {
+                        Text("This router isn't enrolled, so the automatic rollback watchdog won't run for this update.")
+                            .font(.subheadline)
+                            .foregroundStyle(.orange)
+                    }
+                }
+
+                Section {
+                    DisclosureGroup("Advanced") {
+                        VStack(alignment: .leading, spacing: 4) {
+                            TextField("Version", text: $viewModel.advancedVersion, prompt: Text(viewModel.releaseVersion ?? "1.98.9"))
+                                .textInputAutocapitalization(.never)
+                                .autocorrectionDisabled()
+                            if let error = viewModel.advancedVersionError {
+                                Text(error).font(.caption).foregroundStyle(.red)
+                            }
+                        }
+                        VStack(alignment: .leading, spacing: 4) {
+                            TextField("SHA-256", text: $viewModel.advancedSHA256)
+                                .font(.body.monospaced())
+                                .textInputAutocapitalization(.never)
+                                .autocorrectionDisabled()
+                            if let error = viewModel.advancedSHA256Error {
+                                Text(error).font(.caption).foregroundStyle(.red)
+                            }
+                        }
+                    }
+                }
+
+                Section {
+                    Button {
+                        Task { await viewModel.startUpdate() }
+                    } label: {
+                        Text(viewModel.status.installed ? "Update" : "Install")
+                            .frame(maxWidth: .infinity)
+                    }
+                    .disabled(!viewModel.canStartUpdate)
+                }
+            }
+            .navigationTitle(viewModel.status.installed ? "Update Tailscale" : "Install Tailscale")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+            }
+            .task { await viewModel.loadLatestRelease() }
+        }
+    }
+}

--- a/mobile/ios/OpenU60/Features/RouterSettings/Tailscale/TailscaleViewModel.swift
+++ b/mobile/ios/OpenU60/Features/RouterSettings/Tailscale/TailscaleViewModel.swift
@@ -1,0 +1,995 @@
+import SwiftUI
+
+enum TailscaleSeverity {
+    case neutral, good, warning, critical
+
+    var color: Color {
+        switch self {
+        case .neutral: Color.secondary
+        case .good: Color.green
+        case .warning: Color.orange
+        case .critical: Color.red
+        }
+    }
+}
+
+enum TailscalePhase {
+    case notInstalled
+    case updating
+    case notSetUp
+    case turnedOff
+    case turningOff
+    case loggingOut
+    case starting
+    case enrolling
+    case verifyingEnrollment
+    case awaitingBrowserLogin
+    case awaitingSetup
+    case needsLogin
+    case pendingApproval
+    case paused
+    case healthy
+    case degraded
+    case unknown
+
+    var label: String {
+        switch self {
+        case .notInstalled: "Not installed"
+        case .updating: "Updating"
+        case .notSetUp: "Not set up"
+        case .turnedOff: "Off"
+        case .turningOff: "Turning off…"
+        case .loggingOut: "Logging out…"
+        case .starting: "Starting…"
+        case .enrolling: "Setting up…"
+        case .verifyingEnrollment: "Finishing setup…"
+        case .awaitingBrowserLogin: "Waiting for sign-in"
+        case .awaitingSetup: "Not signed in"
+        case .needsLogin: "Sign-in required"
+        case .pendingApproval: "Waiting for approval"
+        case .paused: "Reconnecting…"
+        case .healthy: "Connected"
+        case .degraded: "Connection problem"
+        case .unknown: "Unknown"
+        }
+    }
+
+    var severity: TailscaleSeverity {
+        switch self {
+        case .needsLogin: .critical
+        case .pendingApproval, .degraded: .warning
+        case .healthy: .good
+        default: .neutral
+        }
+    }
+
+    var showsSpinner: Bool {
+        switch self {
+        case .updating, .turningOff, .loggingOut, .starting, .enrolling,
+             .verifyingEnrollment, .awaitingBrowserLogin, .pendingApproval,
+             .paused, .degraded:
+            true
+        default:
+            false
+        }
+    }
+}
+
+/// Client-side operations the server state cannot express on its own.
+enum TailscaleOp {
+    case none
+    case enabling
+    case prewarming
+    case enrolling
+    case verifyingEnrollment
+    case awaitingBrowserLogin
+    case disabling
+    case loggingOut
+    case updating
+    case savingConfig
+}
+
+/// Config transitions dangerous enough to confirm before sending.
+enum TailscaleConfigConfirm: Identifiable {
+    case ssh
+    case route(String)
+    case wakelock
+
+    var id: String {
+        switch self {
+        case .ssh: "ssh"
+        case .route(let cidr): "route:\(cidr)"
+        case .wakelock: "wakelock"
+        }
+    }
+
+    var title: String {
+        switch self {
+        case .ssh: "Allow Tailscale SSH?"
+        case .route(let cidr): "Advertise \(cidr)?"
+        case .wakelock: "Let the router sleep?"
+        }
+    }
+
+    var message: String {
+        switch self {
+        case .ssh:
+            "Devices on your tailnet that your ACLs permit will be able to open a shell on this router. Access is governed by your tailnet ACLs, which this app can't show you."
+        case .route:
+            "This exposes that entire subnet — every device on your LAN — to your tailnet. Subnet routes must also be approved in the Tailscale admin console before they carry traffic."
+        case .wakelock:
+            "Without the wakelock the router's CPU sleeps and the node becomes unreachable, even though it will still look connected. Remote access will be unreliable."
+        }
+    }
+
+    var confirmLabel: String {
+        switch self {
+        case .ssh: "Allow SSH"
+        case .route: "Advertise"
+        case .wakelock: "Allow Sleep"
+        }
+    }
+}
+
+@Observable
+@MainActor
+final class TailscaleViewModel {
+    var status: TailscaleStatus = .empty
+    var isLoading: Bool = false
+    var message: String?
+    var messageIsError: Bool = false
+
+    var op: TailscaleOp = .none
+
+    // Config edit buffers. Seeded on first load and after a successful apply
+    // only — never from a poll, which would erase typing mid-edit.
+    var editHostname: String = ""
+    var editRoutes: String = ""
+    var editSSH: Bool = false
+    var editWakelock: Bool = true
+
+    /// Never persisted, never logged, cleared on every outcome.
+    var authKeyInput: String = ""
+
+    // Blocking alerts
+    var passwordGateBlocked: Bool = false
+    var passwordGateMessage: String?
+    var logoutWarning: String?
+
+    // Sheets and confirms
+    var showEnrollSheet: Bool = false
+    var showUpdateSheet: Bool = false
+    var showDisableConfirm: Bool = false
+    var showLogoutPasswordConfirm: Bool = false
+    /// Owned by the alert so a button tap can't leave it re-presenting itself.
+    var showConfigConfirm: Bool = false
+    var pendingConfigConfirm: TailscaleConfigConfirm?
+
+    // Release lookup (pkgs.tailscale.com)
+    var releaseFetching: Bool = false
+    var releaseVersion: String?
+    var releaseSHA256: String?
+    var releaseError: String?
+    var advancedVersion: String = ""
+    var advancedSHA256: String = ""
+
+    /// The interactive login URL only ever lives in the daemon's memory — the
+    /// agent clears it the moment the backend reaches Running. Never cache it
+    /// beyond the flow.
+    var loginURL: String?
+
+    private let client: AgentClient
+    private let authManager: AuthManager
+    private nonisolated(unsafe) var pollTask: Task<Void, Never>?
+    private var initialLoadDone = false
+    private var degradedPolls = 0
+    private var pollFailures = 0
+    private var requestedUpdateVersion: String?
+    private var acknowledgedConfirms: Set<String> = []
+
+    private let maxPollFailures = 6
+
+    /// The circuit breaker has fired. An op's cap copy must not overwrite
+    /// "Lost connection to the router." — when the router stopped answering at
+    /// all, that is the real story, and the cap copy sends the user chasing the
+    /// wrong thing.
+    private var connectionLost: Bool { pollFailures >= maxPollFailures }
+
+    init(client: AgentClient, authManager: AuthManager) {
+        self.client = client
+        self.authManager = authManager
+    }
+
+    deinit {
+        pollTask?.cancel()
+    }
+
+    // MARK: - Phase
+
+    var phase: TailscalePhase { Self.derivePhase(status, op) }
+
+    /// `state` alone is insufficient: build_status returns "disabled" before any
+    /// CLI call, so a fresh router and a deliberately turned-off one report the
+    /// same state and are told apart only by `enrolled`.
+    static func derivePhase(_ status: TailscaleStatus, _ op: TailscaleOp) -> TailscalePhase {
+        if op == .updating || status.updating || status.state == "updating" { return .updating }
+        if status.state == "not_installed" { return .notInstalled }
+
+        if op == .enrolling { return .enrolling }
+        if op == .verifyingEnrollment { return .verifyingEnrollment }
+        if op == .awaitingBrowserLogin,
+           status.state != "healthy", status.state != "pending_approval" {
+            return .awaitingBrowserLogin
+        }
+        if op == .prewarming || op == .enabling { return .starting }
+        if op == .disabling { return .turningOff }
+        if op == .loggingOut { return .loggingOut }
+
+        switch status.state {
+        case "disabled": return status.enrolled ? .turnedOff : .notSetUp
+        // paused/respawning with enabled==false is the POST /disable race: the
+        // daemon is SIGTERMed but child_pid is cleared later by the supervisor.
+        case "paused": return status.enabled ? .paused : .turningOff
+        case "respawning": return status.enabled ? .starting : .turningOff
+        case "starting": return .starting
+        case "connecting": return .starting
+        case "awaiting_setup": return .awaitingSetup
+        case "needs_login": return .needsLogin
+        case "pending_approval": return .pendingApproval
+        case "healthy": return .healthy
+        case "degraded": return .degraded
+        default: return .unknown
+        }
+    }
+
+    var statusDescription: String {
+        switch phase {
+        case .notInstalled:
+            return "Tailscale isn't installed on this router yet."
+        case .updating:
+            return "Installing Tailscale. This can take several minutes over mobile data. Don't power off the router."
+        case .notSetUp:
+            return "Connect this router to your tailnet to reach it from anywhere."
+        case .turnedOff:
+            return "Remote access is off. This router's sign-in is saved."
+        case .turningOff:
+            return "Disconnecting from your tailnet."
+        case .loggingOut:
+            return "Removing this router's Tailscale identity."
+        case .starting:
+            return "Waiting for the router's clock and mobile data. This can take up to 2 minutes."
+        case .enrolling:
+            return "Connecting this router to your tailnet. This can take up to 2 minutes."
+        case .verifyingEnrollment:
+            return "The router is still working. Checking whether setup completed."
+        case .awaitingBrowserLogin:
+            return "Open the sign-in page and approve this router. This link is valid for about 5 minutes."
+        case .awaitingSetup:
+            return "Tailscale is running but this router hasn't joined a tailnet yet."
+        case .needsLogin:
+            return status.expired
+                ? "This router's node key expired. Sign in again to restore remote access."
+                : "This router's sign-in is no longer valid. Sign in again to restore remote access."
+        case .pendingApproval:
+            return "Approve this router in the Tailscale admin console. Nothing can be done from this app."
+        case .paused:
+            return "Tailscale is reconnecting. This usually clears within a minute."
+        case .healthy:
+            return status.displayDNSName ?? "This router is on your tailnet."
+        case .degraded:
+            return degradedIsPersistent
+                ? "The router is signed in but still not reachable."
+                : "The router is signed in but not reachable. Recovering automatically."
+        case .unknown:
+            return "The router reported a state this app doesn't recognize."
+        }
+    }
+
+    /// The agent's monitor loop self-heals a degraded node, so the first few
+    /// polls offer no action.
+    var degradedIsPersistent: Bool { degradedPolls > 4 }
+
+    // MARK: - Derived UI state
+
+    var actionsDisabled: Bool { isLoading || op != .none || phase == .updating }
+
+    var enrollDisabled: Bool { actionsDisabled || passwordGateBlocked }
+
+    var hostnameError: String? { TailscaleValidator.hostname(editHostname) }
+
+    var routesError: String? { TailscaleValidator.routes(editRoutes) }
+
+    /// Only the changed fields. `/config` is schedulable and a web dashboard
+    /// exists, so a full-state write could silently revert a concurrent change.
+    var configDiff: [String: Any] {
+        var patch: [String: Any] = [:]
+        let hostname = editHostname.trimmingCharacters(in: .whitespaces)
+        if hostname != status.hostname { patch["hostname"] = hostname }
+        let routes = TailscaleValidator.parseRoutes(editRoutes)
+        if routes != status.advertiseRoutes { patch["advertise_routes"] = routes }
+        if editWakelock != status.holdWakelock { patch["hold_wakelock"] = editWakelock }
+        if editSSH != status.tailscaleSSH { patch["tailscale_ssh"] = editSSH }
+        return patch
+    }
+
+    var canApplyConfig: Bool {
+        !actionsDisabled && hostnameError == nil && routesError == nil && !configDiff.isEmpty
+    }
+
+    /// Manual Advanced input wins over the fetched release.
+    var effectiveVersion: String {
+        let manual = advancedVersion.trimmingCharacters(in: .whitespaces)
+        return manual.isEmpty ? (releaseVersion ?? "") : manual
+    }
+
+    var effectiveSHA256: String {
+        let manual = advancedSHA256.trimmingCharacters(in: .whitespaces)
+        return manual.isEmpty ? (releaseSHA256 ?? "") : manual
+    }
+
+    var advancedVersionError: String? {
+        advancedVersion.trimmingCharacters(in: .whitespaces).isEmpty
+            ? nil : TailscaleValidator.version(advancedVersion)
+    }
+
+    var advancedSHA256Error: String? {
+        advancedSHA256.trimmingCharacters(in: .whitespaces).isEmpty
+            ? nil : TailscaleValidator.sha256(advancedSHA256)
+    }
+
+    var canStartUpdate: Bool {
+        !isLoading && op == .none && !releaseFetching
+            && TailscaleValidator.version(effectiveVersion) == nil
+            && TailscaleValidator.sha256(effectiveSHA256) == nil
+    }
+
+    /// Heuristic, and it fails open: it misses a tailnet-side reverse proxy, a
+    /// custom DNS alias, or a subnet route to the LAN address riding the tunnel.
+    /// It supplements the always-on wording in destructive confirms.
+    var isRemoteSession: Bool {
+        guard let host = URLComponents(string: client.baseURL)?.host else { return false }
+        if status.tailscaleIPs.contains(host) { return true }
+        if let dns = status.displayDNSName, host.caseInsensitiveCompare(dns) == .orderedSame { return true }
+        // 100.64.0.0/10
+        let octets = host.split(separator: ".")
+        guard octets.count == 4, let first = Int(octets[0]), let second = Int(octets[1]) else { return false }
+        return first == 100 && (64...127).contains(second)
+    }
+
+    // MARK: - Loading
+
+    func refresh() async {
+        isLoading = true
+        message = nil
+        await fetchStatus(reportFailure: true)
+        isLoading = false
+        // The breaker stops the poll loop permanently, and that loop is the only
+        // thing that reconciles an op it cannot see the end of (.updating), so an
+        // explicit refresh has to revive it. startPolling() is idempotent.
+        startPolling()
+    }
+
+    private func startPolling() {
+        stopPolling()
+        pollTask = Task { [weak self] in
+            while !Task.isCancelled {
+                guard let interval = self?.pollInterval else { return }
+                try? await Task.sleep(for: .seconds(interval))
+                if Task.isCancelled { return }
+                await self?.pollTick()
+            }
+        }
+    }
+
+    private func stopPolling() {
+        pollTask?.cancel()
+        pollTask = nil
+    }
+
+    /// The agent serves a 10s status cache, so a faster poll returns the
+    /// identical object and progress looks frozen.
+    private var pollInterval: TimeInterval {
+        if op != .none { return 10 }
+        switch phase {
+        case .updating, .starting, .paused, .turningOff, .loggingOut, .enrolling,
+             .verifyingEnrollment, .awaitingBrowserLogin, .pendingApproval,
+             .degraded, .unknown:
+            return 10
+        case .healthy, .turnedOff, .notSetUp, .notInstalled, .awaitingSetup, .needsLogin:
+            return 30
+        }
+    }
+
+    private func pollTick() async {
+        // A multi-minute update outlives the screen, so the poll loop — not a
+        // task held across the push — is what reconciles it.
+        let wasUpdating = op == .updating
+        await fetchStatus()
+        // A tick this loop no longer owns must not act: startPolling() cancels the
+        // previous task, and finishUpdate() here would settle an op it can't see.
+        if Task.isCancelled || connectionLost { return }
+        if wasUpdating && !status.updating { finishUpdate() }
+    }
+
+    /// The poll loop stays silent on failure — the circuit breaker speaks for it,
+    /// and a screen that times out by design would otherwise flash errors. The
+    /// breaker lives here rather than in pollTick so it outranks `reportFailure`
+    /// on every path, refresh() included.
+    private func fetchStatus(reportFailure: Bool = false) async {
+        do {
+            let data = try await withReauth { try await self.client.getJSON("/api/tailscale/status") }
+            adopt(TailscaleParser.parse(data))
+            pollFailures = 0
+        } catch {
+            // Cancelling the poll loop must not read as a router failure.
+            if isCancellation(error) { return }
+            pollFailures += 1
+            if connectionLost {
+                stopPolling()
+                showMessage("Lost connection to the router.", isError: true)
+            } else if reportFailure {
+                showMessage("Failed to load Tailscale status: \(error.localizedDescription)", isError: true)
+            }
+        }
+    }
+
+    /// URLSession surfaces task cancellation as URLError.cancelled, which AgentClient
+    /// wraps as .networkError — indistinguishable from a real fault without this.
+    private func isCancellation(_ error: Error) -> Bool {
+        if error is CancellationError { return true }
+        if (error as? URLError)?.code == .cancelled { return true }
+        if case AgentError.networkError(let underlying) = error {
+            return (underlying as? URLError)?.code == .cancelled
+        }
+        return false
+    }
+
+    private func adopt(_ next: TailscaleStatus) {
+        status = next
+        if !initialLoadDone {
+            initialLoadDone = true
+            seedEditBuffers()
+            if next.updating { op = .updating }
+        }
+        degradedPolls = phase == .degraded ? degradedPolls + 1 : 0
+    }
+
+    private func seedEditBuffers() {
+        editHostname = status.hostname
+        editRoutes = status.advertiseRoutes.joined(separator: ", ")
+        editSSH = status.tailscaleSSH
+        editWakelock = status.holdWakelock
+    }
+
+    // MARK: - Enrollment
+
+    /// Never call /setup or /login-url against a cold daemon: ensure_daemon_ready
+    /// runs inside the request and costs up to 180s, which turns /setup into a
+    /// ~278s block. Pre-warming also surfaces the password gate before the user
+    /// pastes a secret, and the needs_login re-auth path 409s without it.
+    /// Returns false when the caller must abort.
+    private func preWarm() async -> Bool {
+        if status.enabled { return true }
+
+        op = .prewarming
+        guard await postEnable() else {
+            if op == .prewarming { op = .none }
+            return false
+        }
+        showMessage("Starting Tailscale… this can take up to 2 minutes on first run.", isError: false)
+
+        let warm: Set<String> = ["awaiting_setup", "needs_login", "connecting", "paused",
+                                 "healthy", "degraded", "pending_approval"]
+        let deadline = Date().addingTimeInterval(180)
+        while Date() < deadline {
+            try? await Task.sleep(for: .seconds(10))
+            await fetchStatus()
+            if status.state == "healthy" {
+                op = .none
+                message = nil
+                showEnrollSheet = false
+                return false
+            }
+            if warm.contains(status.state) {
+                op = .none
+                return true
+            }
+        }
+        op = .none
+        if !connectionLost {
+            showMessage("Tailscale isn't starting. Check that the router has mobile data and its clock is set.", isError: true)
+        }
+        return false
+    }
+
+    func setupWithAuthKey() async {
+        // The agent's mutual exclusion is one-directional — /setup does not
+        // block /login-url — so the client must serialize enrollment itself.
+        guard op == .none else { return }
+        let key = authKeyInput.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !key.isEmpty else { return }
+        guard await preWarm() else { return }
+
+        authKeyInput = ""
+        // Pre-warm's progress copy — and any error from a previous attempt — is
+        // spent. The sheet renders `.enrolling` from `op` alone.
+        message = nil
+        op = .enrolling
+        do {
+            let data = try await withReauth {
+                try await self.client.postJSONSlow("/api/tailscale/setup", body: ["auth_key": key])
+            }
+            op = .none
+            // The 200 body IS the refreshed status payload — no follow-up GET.
+            adopt(TailscaleParser.parse(data))
+            showEnrollSheet = false
+            if status.state == "pending_approval" {
+                showMessage("Setup completed. Approve this router in your Tailscale admin console.", isError: false)
+            } else {
+                showMessage("This router is now on your tailnet.", isError: false)
+            }
+        } catch {
+            // A client timeout is not a failure: `up` has a 90s hard kill and is
+            // very likely still succeeding. Never re-send the key — one-off keys
+            // die on use and a retry hits 409.
+            if isTimeout(error) {
+                await verifyEnrollment()
+                return
+            }
+            op = .none
+            guard let api = apiError(error) else {
+                showMessage("Failed: \(error.localizedDescription)", isError: true)
+                return
+            }
+            switch api.status {
+            case 403:
+                blockOnPasswordGate(api.message)
+            case 502:
+                showMessage("Setup failed: \(api.message). Enter a fresh auth key — one-off keys can't be reused.", isError: true)
+            default:
+                showMessage(api.message, isError: true)
+            }
+        }
+    }
+
+    private func verifyEnrollment() async {
+        op = .verifyingEnrollment
+        let deadline = Date().addingTimeInterval(240)
+        while Date() < deadline {
+            try? await Task.sleep(for: .seconds(10))
+            await fetchStatus()
+            if status.state == "healthy" {
+                op = .none
+                showEnrollSheet = false
+                showMessage("This router is now on your tailnet.", isError: false)
+                return
+            }
+            if status.state == "pending_approval" {
+                op = .none
+                showEnrollSheet = false
+                showMessage("Setup completed. Approve this router in your Tailscale admin console.", isError: false)
+                return
+            }
+        }
+        op = .none
+        if !connectionLost {
+            showMessage("Setup didn't complete. Enter a fresh auth key — one-off keys can't be reused.", isError: true)
+        }
+    }
+
+    func signInWithBrowser() async {
+        guard op == .none else { return }
+        guard await preWarm() else { return }
+
+        authKeyInput = ""
+        loginURL = nil
+        op = .awaitingBrowserLogin
+        showEnrollSheet = false
+        message = nil
+
+        do {
+            let data = try await withReauth { try await self.client.postJSONSlow("/api/tailscale/login-url") }
+            // 202 and 200 are indistinguishable here — both collapse into the
+            // client's 200..299 success arm — so branch on the payload.
+            if let url = data["login_url"] as? String, !url.isEmpty { loginURL = url }
+        } catch {
+            if !isTimeout(error) {
+                op = .none
+                if let api = apiError(error), api.status == 403 {
+                    blockOnPasswordGate(api.message)
+                } else if let api = apiError(error) {
+                    showMessage(api.message, isError: true)
+                } else {
+                    showMessage("Failed: \(error.localizedDescription)", isError: true)
+                }
+                return
+            }
+        }
+
+        let deadline = Date().addingTimeInterval(310)
+        while Date() < deadline {
+            guard op == .awaitingBrowserLogin else { return }
+            try? await Task.sleep(for: .seconds(10))
+            await fetchStatus()
+            // Mirror the field, never latch it: the agent drops the URL the moment
+            // the backend reaches Running and whenever the daemon exits, and a
+            // consumed URL must stop being tappable. The agent's own cache seeds
+            // every payload, so a still-live URL is never dropped here.
+            loginURL = status.loginURL.flatMap { $0.isEmpty ? nil : $0 }
+            if status.state == "healthy" {
+                finishBrowserLogin("This router is now on your tailnet.")
+                return
+            }
+            if status.state == "pending_approval" {
+                finishBrowserLogin("Setup completed. Approve this router in your Tailscale admin console.")
+                return
+            }
+        }
+        op = .none
+        loginURL = nil
+        if !connectionLost {
+            showMessage("Sign-in didn't complete in time. Try again.", isError: true)
+        }
+    }
+
+    private func finishBrowserLogin(_ text: String) {
+        op = .none
+        loginURL = nil
+        showEnrollSheet = false
+        showMessage(text, isError: false)
+    }
+
+    // MARK: - Enable / disable
+
+    /// POST /api/tailscale/enable. Returns false when the caller must abort.
+    /// A 500 here is never permanent: the same "update in progress" condition
+    /// yields 409 on setup/login-url/logout but 500 here, so reconcile from
+    /// /status rather than matching the string.
+    private func postEnable() async -> Bool {
+        do {
+            let _ = try await withReauth { try await self.client.postJSON("/api/tailscale/enable") }
+            passwordGateBlocked = false
+            passwordGateMessage = nil
+            return true
+        } catch {
+            guard let api = apiError(error) else {
+                showMessage("Failed: \(error.localizedDescription)", isError: true)
+                return false
+            }
+            switch api.status {
+            case 403:
+                blockOnPasswordGate(api.message)
+            case 500:
+                await fetchStatus()
+                if status.updating {
+                    op = .updating
+                } else {
+                    showMessage(api.message, isError: true)
+                }
+            default:
+                showMessage(api.message, isError: true)
+            }
+            return false
+        }
+    }
+
+    func enableRemoteAccess() async {
+        guard op == .none else { return }
+        op = .enabling
+        guard await postEnable() else {
+            if op == .enabling { op = .none }
+            return
+        }
+        showMessage("Turning on remote access…", isError: false)
+
+        // `respawning` for ~2 min and a transient `paused` are both expected
+        // here — the supervisor gates on a sane clock and a connected WAN, and
+        // the monitor loop self-heals a persisted WantRunning=false.
+        let terminal: Set<String> = ["healthy", "degraded", "needs_login", "awaiting_setup", "pending_approval"]
+        let deadline = Date().addingTimeInterval(180)
+        while Date() < deadline {
+            try? await Task.sleep(for: .seconds(10))
+            await fetchStatus()
+            if terminal.contains(status.state) {
+                op = .none
+                // The status card carries the outcome from here. Leaving the
+                // progress banner up would contradict it.
+                message = nil
+                return
+            }
+        }
+        op = .none
+        if !connectionLost {
+            showMessage("Still starting — check back shortly.", isError: false)
+        }
+    }
+
+    func disable() async {
+        guard op == .none else { return }
+        showDisableConfirm = false
+        op = .disabling
+        do {
+            let _ = try await withReauth { try await self.client.postJSONSlow("/api/tailscale/disable") }
+            showMessage("Remote access is off.", isError: false)
+        } catch {
+            if !isTimeout(error) {
+                op = .none
+                if let api = apiError(error) {
+                    showMessage(api.message, isError: true)
+                } else {
+                    showMessage("Failed: \(error.localizedDescription)", isError: true)
+                }
+                return
+            }
+        }
+
+        // kill_child only SIGTERMs and child_pid is cleared by the supervisor
+        // afterwards, so /status reports daemon_running:true for a moment. The
+        // .turningOff phase absorbs exactly that — never render it as a failure.
+        let deadline = Date().addingTimeInterval(30)
+        while Date() < deadline {
+            try? await Task.sleep(for: .seconds(10))
+            await fetchStatus()
+            if status.state == "disabled" { break }
+        }
+        op = .none
+    }
+
+    // MARK: - Config
+
+    func applyConfig() async {
+        guard op == .none, hostnameError == nil, routesError == nil else { return }
+        let patch = configDiff
+        guard !patch.isEmpty else { return }
+
+        if let confirm = nextConfirm(for: patch) {
+            pendingConfigConfirm = confirm
+            showConfigConfirm = true
+            return
+        }
+        await sendConfig(patch)
+    }
+
+    func confirmPendingConfig() async {
+        guard let confirm = pendingConfigConfirm else { return }
+        acknowledgedConfirms.insert(confirm.id)
+        pendingConfigConfirm = nil
+        await applyConfig()
+    }
+
+    /// Cancelling abandons the whole apply, so the acknowledgements go too.
+    func cancelPendingConfig() {
+        pendingConfigConfirm = nil
+        acknowledgedConfirms.removeAll()
+    }
+
+    private func nextConfirm(for patch: [String: Any]) -> TailscaleConfigConfirm? {
+        if patch["tailscale_ssh"] as? Bool == true, !acknowledgedConfirms.contains("ssh") {
+            return .ssh
+        }
+        if let routes = patch["advertise_routes"] as? [String] {
+            for route in routes
+            where !status.advertiseRoutes.contains(route) && !acknowledgedConfirms.contains("route:\(route)") {
+                return .route(route)
+            }
+        }
+        if patch["hold_wakelock"] as? Bool == false, !acknowledgedConfirms.contains("wakelock") {
+            return .wakelock
+        }
+        return nil
+    }
+
+    private func sendConfig(_ patch: [String: Any]) async {
+        op = .savingConfig
+        isLoading = true
+        defer {
+            isLoading = false
+            op = .none
+        }
+        do {
+            // Real JSON types: TsConfigPatch is native serde. The "1"/"0" strings
+            // the neighbouring ubus screens send would fail to deserialize here.
+            let data = try await withReauth {
+                try await self.client.putJSONSlow("/api/tailscale/config", body: patch)
+            }
+            adopt(TailscaleParser.parse(data))
+            seedEditBuffers()
+            acknowledgedConfirms.removeAll()
+            // The agent only shells `tailscale set` when enabled && daemon_up &&
+            // the state file exists; otherwise it silently persists the patch for
+            // later. Both return 200, so approximate rather than claim "applied".
+            if status.enabled && status.daemonRunning && status.enrolled {
+                showMessage("Settings applied.", isError: false)
+            } else {
+                showMessage("Saved. These will apply the next time Tailscale starts.", isError: false)
+            }
+        } catch {
+            if let api = apiError(error), api.status == 502 {
+                // The endpoint is transactional — the patch is applied to a
+                // candidate copy and nothing persists on failure.
+                showMessage("Tailscale rejected the change. Nothing was saved.", isError: true)
+                await fetchStatus()
+                seedEditBuffers()
+            } else if let api = apiError(error) {
+                showMessage(api.message, isError: true)
+            } else {
+                showMessage("Failed: \(error.localizedDescription)", isError: true)
+            }
+        }
+    }
+
+    // MARK: - Logout
+
+    func logout() async {
+        guard op == .none else { return }
+        op = .loggingOut
+        do {
+            let data = try await withReauth { try await self.client.postJSONSlow("/api/tailscale/logout") }
+            op = .none
+            // The warning is the ONLY failure channel — logout returns 200 even
+            // when the node key was not invalidated, which leaves a live machine
+            // on the tailnet while the local identity is already destroyed.
+            if let warning = data["warning"] as? String, !warning.isEmpty {
+                logoutWarning = warning
+            } else {
+                showMessage("Logged out. This router has been removed from your tailnet.", isError: false)
+            }
+        } catch {
+            op = .none
+            if isTimeout(error) {
+                // The local identity is destroyed unconditionally, so this is not
+                // a failure — but we never saw `warning`, so we cannot claim the
+                // node key was invalidated.
+                showMessage("Logged out. If this router still appears in your admin console, remove it there.", isError: false)
+            } else if let api = apiError(error), api.status == 409 {
+                showMessage("Can't log out while an update is running.", isError: true)
+            } else if let api = apiError(error) {
+                showMessage(api.message, isError: true)
+                return
+            } else {
+                showMessage("Failed: \(error.localizedDescription)", isError: true)
+                return
+            }
+        }
+        await fetchStatus()
+        seedEditBuffers()
+    }
+
+    func verifyPassword(_ input: String) -> Bool {
+        guard let stored = KeychainHelper.load(key: "router_password") else { return false }
+        return input == stored
+    }
+
+    func dismissLogoutWarning() {
+        logoutWarning = nil
+    }
+
+    func copyToClipboard(_ value: String) {
+        UIPasteboard.general.string = value
+        showMessage("Copied to clipboard", isError: false)
+    }
+
+    // MARK: - Install / update
+
+    func loadLatestRelease() async {
+        releaseFetching = true
+        releaseError = nil
+        do {
+            let release = try await TailscaleReleaseFetcher.resolveLatest()
+            releaseVersion = release.version
+            releaseSHA256 = release.sha256
+        } catch {
+            releaseVersion = nil
+            releaseSHA256 = nil
+            releaseError = error.localizedDescription
+        }
+        releaseFetching = false
+    }
+
+    func startUpdate() async {
+        guard op == .none else { return }
+        let version = effectiveVersion
+        let sha256 = effectiveSHA256
+        guard TailscaleValidator.version(version) == nil,
+              TailscaleValidator.sha256(sha256) == nil else { return }
+
+        isLoading = true
+        defer { isLoading = false }
+        do {
+            // Default client — the handler returns 202 immediately.
+            let _ = try await withReauth {
+                try await self.client.postJSON("/api/tailscale/update", body: ["version": version, "sha256": sha256])
+            }
+            beginUpdate(requested: version)
+        } catch {
+            guard let api = apiError(error) else {
+                showMessage("Failed: \(error.localizedDescription)", isError: true)
+                return
+            }
+            if api.status == 409 {
+                // Reconcile from status rather than erroring — match on endpoint
+                // and status, never on the string.
+                await fetchStatus()
+                if status.updating {
+                    beginUpdate(requested: nil)
+                } else {
+                    showMessage(api.message, isError: true)
+                }
+            } else {
+                showMessage(api.message, isError: true)
+            }
+        }
+    }
+
+    private func beginUpdate(requested: String?) {
+        requestedUpdateVersion = requested
+        op = .updating
+        showUpdateSheet = false
+        showMessage("Updating Tailscale. This can take several minutes. Don't power off the router.", isError: false)
+    }
+
+    private func finishUpdate() {
+        op = .none
+        let requested = requestedUpdateVersion
+        requestedUpdateVersion = nil
+
+        // last_update is in-memory only and is NOT persisted, so an agent restart
+        // during the update leaves it null. That is an unknown outcome, never a
+        // success.
+        guard let result = status.lastUpdate else {
+            showMessage("Update finished, but the result is unknown (the agent may have restarted). Check the running version below.", isError: true)
+            return
+        }
+        guard result.ok else {
+            showMessage("Update failed: \(result.error ?? "Unknown error")", isError: true)
+            return
+        }
+        if let requested, status.pinnedVersion != requested {
+            showMessage("Update reported success but the version didn't change.", isError: true)
+        } else {
+            showMessage("Updated to \(result.version).", isError: false)
+        }
+    }
+
+    // MARK: - Helpers
+
+    /// Retries once after a silent re-auth, and only on the typed 401. This
+    /// screen long-polls across the 3600s token TTL, but it also times out by
+    /// design — the Dashboard idiom of re-authing on any error would spray
+    /// spurious logins. A 403 must never reach this: it is not an auth failure.
+    private func withReauth<T>(_ call: () async throws -> T) async throws -> T {
+        do {
+            return try await call()
+        } catch AgentError.unauthorized {
+            guard await authManager.reauthenticate() else { throw AgentError.unauthorized }
+            return try await call()
+        }
+    }
+
+    private func apiError(_ error: Error) -> (status: Int, message: String)? {
+        guard let agentError = error as? AgentError,
+              case .apiError(let status, let message) = agentError else { return nil }
+        return (status, message)
+    }
+
+    private func isTimeout(_ error: Error) -> Bool {
+        guard let agentError = error as? AgentError, case .timeout = agentError else { return false }
+        return true
+    }
+
+    private func blockOnPasswordGate(_ serverMessage: String) {
+        passwordGateBlocked = true
+        passwordGateMessage = serverMessage
+        // The card is the gate's only explanation and it renders on the list
+        // behind the enroll sheet. The gate is terminal and not fixable from the
+        // API, so the sheet can do nothing but hide the reason its own buttons
+        // just went dead — close it. Dismissal clears the pasted key too.
+        message = nil
+        showEnrollSheet = false
+    }
+
+    private func showMessage(_ text: String, isError: Bool) {
+        message = text
+        messageIsError = isError
+    }
+}


### PR DESCRIPTION
## Summary

- Add Tailscale status, setup, authentication, enable/disable, update, and recovery flows to both the iOS and Android apps.
- Add platform-specific Tailscale models, view models, screens, navigation, and router-settings entry points while keeping behavior aligned across both apps.
- Extend both mobile API clients with Tailscale operations, structured agent-error handling, and long-operation timeout support.
- Fetch the current Tailscale version and SHA-256 metadata from `pkgs.tailscale.com` over TLS, with an advanced manual override for explicitly pinned values.
- Apply adversarial-review fixes for polling, cancellation, circuit-breaker, expiry-copy, and stale login-state behavior.

## Dependencies

- #3 has been merged into `main` for the Android baseline fixes, icons, and localization.
- #13 has been merged into `main` for the Rust agent API consumed by these apps.
- The temporary local Android baseline-fix commit was dropped before this branch was published.

## Verification

- Android forced-clean compile:
  - Gradle 8.9 with JDK 17
  - `clean :app:compileDebugKotlin --rerun-tasks`
  - `BUILD SUCCESSFUL`; 16 tasks executed
- iOS forced-clean simulator build:
  - Regenerated the project with XcodeGen
  - `xcodebuild ... clean build` with code signing disabled
  - Build completed successfully
- `git diff --check origin/main...HEAD` passed.

This repository currently has no automated mobile test suite, so verification is compile/build based.
