### PR TITLE
fix(tailscale): pass required params to wakelock ubus calls

### DIFF
--- a/zte-agent/src/tailscale/mod.rs
+++ b/zte-agent/src/tailscale/mod.rs
@@ -59,6 +59,8 @@ pub struct TailscaleManager {
     last_update: Mutex<Option<Value>>,
     login_url: Mutex<Option<String>>,
     wakelock_held: AtomicBool,
+    /// Descriptor returned by createWakelock; destroyWakelock requires it.
+    wakelock_fd: Mutex<Option<String>>,
 }
 
 fn unix_now() -> i64 {
@@ -149,6 +151,7 @@ impl TailscaleManager {
             last_update: Mutex::new(None),
             login_url: Mutex::new(None),
             wakelock_held: AtomicBool::new(false),
+            wakelock_fd: Mutex::new(None),
         }
     }
 
@@ -688,9 +691,29 @@ impl TailscaleManager {
 
     // --- Wakelock ---
 
+    /// `ubus -v list zwrt_zte_sleep_faw.wakelock` on 2025-12 firmware:
+    ///   "createWakelock":{"lockName":"String"}
+    ///   "destroyWakelock":{"fd":"String"}
+    /// Calling either with an empty object fails with "Invalid command", and
+    /// `destroy` needs the descriptor that `create` hands back.
     fn acquire_wakelock(&self) {
-        match ubus::call("zwrt_zte_sleep_faw.wakelock", "createWakelock", Some("{}")) {
-            Ok(_) => self.wakelock_held.store(true, Ordering::SeqCst),
+        match ubus::call(
+            "zwrt_zte_sleep_faw.wakelock",
+            "createWakelock",
+            Some(r#"{"lockName":"zte-agent"}"#),
+        ) {
+            Ok(resp) => {
+                // Depending on the firmware, fd arrives as a number or a string.
+                let fd = resp
+                    .get("fd")
+                    .map(|v| match v {
+                        serde_json::Value::String(s) => s.clone(),
+                        other => other.to_string(),
+                    })
+                    .unwrap_or_default();
+                *self.wakelock_fd.lock().unwrap() = if fd.is_empty() { None } else { Some(fd) };
+                self.wakelock_held.store(true, Ordering::SeqCst);
+            }
             Err(e) => eprintln!("[tailscale] createWakelock: {e}"),
         }
     }
@@ -699,8 +722,21 @@ impl TailscaleManager {
         if !self.wakelock_held.load(Ordering::SeqCst) {
             return;
         }
-        match ubus::call("zwrt_zte_sleep_faw.wakelock", "destroyWakelock", Some("{}")) {
-            Ok(_) => self.wakelock_held.store(false, Ordering::SeqCst),
+        let fd = self.wakelock_fd.lock().unwrap().clone();
+        let params = match fd {
+            Some(fd) => format!(r#"{{"fd":"{fd}"}}"#),
+            // Without an fd there is nothing to release; clear the flag so the
+            // next acquire starts from a clean lock.
+            None => {
+                self.wakelock_held.store(false, Ordering::SeqCst);
+                return;
+            }
+        };
+        match ubus::call("zwrt_zte_sleep_faw.wakelock", "destroyWakelock", Some(&params)) {
+            Ok(_) => {
+                self.wakelock_held.store(false, Ordering::SeqCst);
+                *self.wakelock_fd.lock().unwrap() = None;
+            }
             Err(e) => eprintln!("[tailscale] destroyWakelock: {e}"),
         }
     }


### PR DESCRIPTION
## Problem

`createWakelock` and `destroyWakelock` are called with an empty JSON object:

```rust
ubus::call("zwrt_zte_sleep_faw.wakelock", "createWakelock", Some("{}"))
```

The firmware rejects both with `Invalid command`. The agent logs it and carries
on, so `wakelock_held` stays `false` and the wakelock never actually holds —
the feature silently does nothing.

Observed in the agent log:

```
[tailscale] createWakelock: ubus call zwrt_zte_sleep_faw.wakelock createWakelock failed:
Command failed: ubus call zwrt_zte_sleep_faw.wakelock createWakelock {} (Unknown error: -1)
Command failed: Invalid command
```

## Actual signature

```
$ ubus -v list zwrt_zte_sleep_faw.wakelock
'zwrt_zte_sleep_faw.wakelock' @f91765d1
        "createWakelock":{"lockName":"String"}
        "destroyWakelock":{"fd":"String"}
        "WakeLock":{"fd":"Integer"}
        "WakeUnlock":{"fd":"Integer"}
        "enableAutoSleep":{"switch":"Boolean"}
        ...
```

`createWakelock` needs `lockName`, and `destroyWakelock` needs the `fd` that
`create` returns — which the agent never stored.

## Change

* pass `{"lockName":"zte-agent"}` on create
* keep the returned `fd` in a new `wakelock_fd` field and pass it to destroy
* accept `fd` as either a number or a string (it varies between builds)
* if there is no `fd`, clear the flag instead of issuing a doomed destroy call

## Verification

Tested on ZTE U60 Pro, firmware `CN_ZTE_MU5250V1.0.0B27` (build 2025-12-25),
kernel 5.15.185-perf. After the change `/api/tailscale/status` reports
`"wakelock_held": true` and the error disappears from the log.

Worth noting for anyone chasing the same thing: on this unit the wakelock turns
out not to matter, because autosleep is disabled anyway —
`uci get zwrt_sleep.ztmp_switch.sleepSwitch` is `0`, `/sys/power/autosleep`
does not exist, and the system already holds `sysZteSleepLock`. The fix still
seems right for units where sleep is enabled.

---

**Disclosure:** this patch was written by an AI assistant (Claude) working on my
device, and I verified the behaviour on hardware. I don't read Rust and haven't
reviewed the code line by line, so please review it as you would any unfamiliar
contribution.
