### PR TITLE
fix(setup): don't rely on adb shell exit codes

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -338,6 +338,21 @@ rpush() {
     fi
 }
 
+# Remote test that works over both transports.
+#
+# `adb shell` does not propagate the remote exit code (it reports the exit
+# status of adb itself), so `if rcmd "grep -q ..."` was always true and the
+# script happily reported files as present when they were not. Echo a marker
+# and inspect the output instead.
+rtest() {
+    local out
+    out=$(rcmd "if $1; then echo __RTEST_YES__; else echo __RTEST_NO__; fi" 2>/dev/null)
+    case "$out" in
+        *__RTEST_YES__*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
 # ── Step 3: Get zte-agent binary ─────────────────────────────────────
 if [ "$BUILD_CHOICE" = "1" ]; then
     info "Downloading zte-agent from GitHub releases..."
@@ -378,7 +393,7 @@ fi
 # Escape single quotes for safe embedding in sh single-quoted string
 SAFE_PASSWORD=$(printf '%s' "$AGENT_PASSWORD" | sed "s/'/'\\\\''/g")
 
-if rcmd "grep -qF '${SAFE_PASSWORD}' $STARTUP_SCRIPT 2>/dev/null"; then
+if rtest "grep -qF '${SAFE_PASSWORD}' $STARTUP_SCRIPT 2>/dev/null"; then
     ok "Startup script already up to date."
 else
     info "Creating startup script..."
@@ -395,7 +410,7 @@ fi
 # ── Step 6: Update rc.local for boot persistence ────────────────────
 info "Configuring auto-start on boot..."
 RC_LINE="sh $STARTUP_SCRIPT"
-if rcmd "grep -qF '$RC_LINE' /etc/rc.local 2>/dev/null"; then
+if rtest "grep -qF '$RC_LINE' /etc/rc.local 2>/dev/null"; then
     ok "rc.local already configured."
 else
     rcmd "grep -q '^exit 0' /etc/rc.local \
@@ -471,7 +486,7 @@ if [ "$SETUP_SSH" = "y" ] || [ "$SETUP_SSH" = "Y" ]; then
     info "Setting up dropbear SSH server..."
 
     # Check if dropbear is already present
-    if adb shell "test -x /usr/sbin/dropbear" 2>/dev/null; then
+    if rtest "test -x /usr/sbin/dropbear"; then
         ok "Dropbear already installed."
     else
         info "Downloading dropbear for aarch64..."
@@ -489,7 +504,7 @@ if [ "$SETUP_SSH" = "y" ] || [ "$SETUP_SSH" = "Y" ]; then
     info "Configuring SSH keys..."
     adb shell "mkdir -p /etc/dropbear && chmod 700 /etc/dropbear"
     PUBKEY=$(cat "$SSH_PUB")
-    if adb shell "grep -qF '$PUBKEY' /etc/dropbear/authorized_keys 2>/dev/null"; then
+    if rtest "grep -qF '$PUBKEY' /etc/dropbear/authorized_keys 2>/dev/null"; then
         ok "SSH key already authorized."
     else
         adb shell "echo '$PUBKEY' >> /etc/dropbear/authorized_keys"
@@ -499,7 +514,7 @@ if [ "$SETUP_SSH" = "y" ] || [ "$SETUP_SSH" = "Y" ]; then
 
     # Create dropbear startup script
     DROPBEAR_STARTUP=/data/local/tmp/start_dropbear.sh
-    if adb shell "test -x $DROPBEAR_STARTUP" 2>/dev/null; then
+    if rtest "test -x $DROPBEAR_STARTUP"; then
         ok "Dropbear startup script already exists."
     else
         adb shell "cat > $DROPBEAR_STARTUP" <<'DBBOOT'
@@ -512,7 +527,7 @@ DBBOOT
 
     # Add to rc.local if not already there
     DB_RC_LINE="sh $DROPBEAR_STARTUP"
-    if adb shell "grep -qF '$DB_RC_LINE' /etc/rc.local 2>/dev/null"; then
+    if rtest "grep -qF '$DB_RC_LINE' /etc/rc.local 2>/dev/null"; then
         ok "Dropbear rc.local entry already configured."
     else
         adb shell "grep -q '^exit 0' /etc/rc.local \
@@ -522,7 +537,7 @@ DBBOOT
     fi
 
     # Start dropbear now
-    if adb shell "pidof dropbear" >/dev/null 2>&1; then
+    if rtest "pidof dropbear >/dev/null 2>&1"; then
         ok "Dropbear already running on port $SSH_PORT."
     else
         info "Starting dropbear..."


### PR DESCRIPTION
## Problem

`adb shell` returns the exit status of `adb` itself, not of the remote command.
Every conditional that goes through `rcmd` therefore evaluates as **true** over
the ADB transport, regardless of what happened on the device.

That makes `setup.sh` report success for work it then skips:

```
[+] Startup script already up to date.
[*] Configuring auto-start on boot...
[+] rc.local already configured.
[*] Starting zte-agent...
sh: can't open '/data/local/tmp/start_zte_agent.sh': No such file or directory
[+] Agent (re)started.
```

Neither file existed. `grep -qF` failed on the device, `adb shell` still exited
0, so both creation steps were skipped and the agent never started. The final
verification then fails with a JSON decode traceback, which points at the
verification step rather than the real cause.

The same applies to the dropbear section, where the checks additionally call
`adb shell` directly and so are wrong on the SSH transport too.

## Change

Adds an `rtest()` helper that works over both transports by echoing a marker
and inspecting stdout:

```sh
rtest() {
    local out
    out=$(rcmd "if $1; then echo __RTEST_YES__; else echo __RTEST_NO__; fi" 2>/dev/null)
    case "$out" in
        *__RTEST_YES__*) return 0 ;;
        *) return 1 ;;
    esac
}
```

and routes the seven affected conditionals through it. No behaviour changes when
the checks were already correct — it only stops them from silently passing.

## Verification

Reproduced on ZTE U60 Pro, firmware `CN_ZTE_MU5250V1.0.0B27` (build 2025-12-25),
over the ADB transport: before the change both files were missing while the
script reported them as present; after it, they get created and the agent starts.
`bash -n setup.sh` passes.

Note this is a different failure from #2 — that one was `set -e` combined with
`curl -sf` in `ubus_call()`, fixed in v2.0.1. This one is downstream of it and
only shows up once login succeeds.

---

**Disclosure:** this patch was written by an AI assistant (Claude) working on my
device, and I verified the behaviour on hardware. I haven't reviewed the shell
code line by line, so please review it as you would any unfamiliar contribution.
