### PR TITLE
fix(sms): honour poll_interval_secs and wake on the received-SMS counter

### DIFF
--- a/zte-agent/src/sms_forward.rs
+++ b/zte-agent/src/sms_forward.rs
@@ -539,6 +539,56 @@ pub struct SmsForwarder {
     wan_connected: AtomicBool,
 }
 
+/// `HH:MM:SS` for log lines, so latency can be measured from the log alone.
+/// Note the device clock may be offset from real UTC — compare against itself,
+/// not against other machines.
+fn log_ts() -> String {
+    let mut t: i64 = 0;
+    let mut tm: libc::tm = unsafe { std::mem::zeroed() };
+    unsafe {
+        libc::time(&mut t);
+        libc::localtime_r(&t, &mut tm);
+    }
+    format!("{:02}:{:02}:{:02}", tm.tm_hour, tm.tm_min, tm.tm_sec)
+}
+
+/// Read the firmware's received-SMS counter.
+///
+/// `zwrt_wms.config.sms_received_flag` is bumped by the WMS daemon whenever it
+/// stores an incoming message — once per *part*, so a 7-part message advances
+/// it by 7. The value lives in uci runtime state and is not flushed to flash on
+/// every change, so reading it is cheap and causes no wear.
+fn read_received_counter() -> Option<u64> {
+    ubus::uci_get("zwrt_wms.config.sms_received_flag")
+        .ok()?
+        .trim()
+        .parse()
+        .ok()
+}
+
+/// Sleep up to `max_secs`, returning early when the counter moves.
+///
+/// This is what makes delivery prompt without polling the message list: on
+/// firmware where `zwrt_wms_status_event` never fires, the counter is the only
+/// signal that something arrived. Reading it takes well under a millisecond, so
+/// a one-second tick is affordable, and the full interval still elapses as a
+/// backstop in case the counter behaves differently on another build.
+fn wait_for_new_sms(max_secs: u64) {
+    let Some(start_value) = read_received_counter() else {
+        // No counter on this firmware — behave exactly as before.
+        std::thread::sleep(Duration::from_secs(max_secs));
+        return;
+    };
+
+    for _ in 0..max_secs {
+        std::thread::sleep(Duration::from_secs(1));
+        if read_received_counter().is_some_and(|v| v != start_value) {
+            eprintln!("[sms_forward] {} counter moved -> waking up", log_ts());
+            return;
+        }
+    }
+}
+
 impl SmsForwarder {
     pub fn new() -> Self {
         let config = fs::read_to_string(CONFIG_PATH)
@@ -677,8 +727,41 @@ impl SmsForwarder {
         self.init_watermark();
 
         loop {
-            // Wait for event OR 5-min fallback timeout
-            match rx.recv_timeout(Duration::from_secs(300)) {
+            // Wait for an event, the received-SMS counter to move, or the
+            // configured interval to elapse — whichever comes first.
+            //
+            // `zwrt_wms_status_event` is never emitted on some firmware builds
+            // (2025-12 among them). Waiting on the channel alone therefore means
+            // every message waits out the full interval, so the counter is polled
+            // once a second alongside it. Reading it costs well under a
+            // millisecond, and it moves the moment the daemon stores a message.
+            let interval = self.config.lock().unwrap().poll_interval_secs.max(10);
+            let counter_before = read_received_counter();
+            let mut ticks = 0u64;
+
+            let outcome = loop {
+                match rx.recv_timeout(Duration::from_secs(1)) {
+                    Ok(event) => break Ok(Some(event)),
+                    Err(mpsc::RecvTimeoutError::Timeout) => {
+                        ticks += 1;
+                        if counter_before.is_some()
+                            && read_received_counter() != counter_before
+                        {
+                            eprintln!("[sms_forward] {} counter moved -> waking up", log_ts());
+                            break Ok(None);
+                        }
+                        if ticks >= interval {
+                            break Ok(None);
+                        }
+                    }
+                    Err(e) => break Err(e),
+                }
+            };
+
+            match outcome.map_or_else(Err, |opt| match opt {
+                Some(event) => Ok(event),
+                None => Err(mpsc::RecvTimeoutError::Timeout),
+            }) {
                 Ok(event) => {
                     if event["wms_status"].as_str() != Some("new_sms_received") {
                         continue;
@@ -730,11 +813,12 @@ impl SmsForwarder {
         loop {
             self.poll_once();
             let interval = self.config.lock().unwrap().poll_interval_secs.max(10);
-            std::thread::sleep(Duration::from_secs(interval));
+            wait_for_new_sms(interval);
         }
     }
 
     fn process_new_messages(&self, after_id: u64) {
+        eprintln!("[sms_forward] {} fetching messages after id {after_id}", log_ts());
         let messages = match fetch_new_messages(after_id) {
             Ok(msgs) => msgs,
             Err(e) => {
@@ -748,7 +832,8 @@ impl SmsForwarder {
         }
 
         eprintln!(
-            "[sms_forward] found {} new message(s) after id {after_id}",
+            "[sms_forward] {} fetched {} new message(s) after id {after_id}",
+            log_ts(),
             messages.len()
         );
 
@@ -912,8 +997,12 @@ fn forward_with_retry(
     let mut last_err = String::new();
 
     for attempt in 0..MAX_RETRIES {
+        eprintln!("[sms_forward] {} delivering to destination", log_ts());
         match forward_to(dest, sms, agent) {
-            Ok(()) => return Ok(()),
+            Ok(()) => {
+                eprintln!("[sms_forward] {} delivered", log_ts());
+                return Ok(());
+            }
             Err(e) => {
                 eprintln!(
                     "[sms_forward] attempt {}/{MAX_RETRIES} failed for SMS {} -> {}: {e}",


### PR DESCRIPTION
## Problem

On firmware where `zwrt_wms_status_event` is never emitted, every incoming SMS
waits out the full fallback timeout before being forwarded. Two separate issues
compound there:

**1. `event_loop()` ignores `poll_interval_secs`.** It waits a hardcoded 300s:

```rust
match rx.recv_timeout(Duration::from_secs(300)) {
```

`poll_interval_secs` is only honoured by `poll_loop()`, which runs solely when
the event channel disconnects. So on a device that never sees the event, the
setting has no effect on the code path that actually runs — I spent a while
confused about why lowering it changed nothing.

**2. Nothing else signals an incoming message.** Waiting on the channel alone
means the timeout *is* the latency.

Measured on my unit with a 20s interval: 27s end-to-end, 18s of which was the
forwarder sleeping after the daemon had already stored the message.

## Change

`zwrt_wms.config.sms_received_flag` is bumped by `zte_topsw_wms` as soon as it
stores an incoming message. Both wait paths now poll it once a second alongside
their existing wait:

* `event_loop()` waits on the channel in 1s steps and checks the counter between
  them — so it still reacts to the event on firmware that does emit it, and
  additionally to the counter where it doesn't
* `poll_loop()` returns early instead of sleeping out the whole interval
* `poll_interval_secs` is now honoured in both

Reading the counter costs well under a millisecond (`uci get`), and the value
lives in uci runtime state rather than being flushed to flash on every change,
so this adds no write wear.

Log lines in the forwarder got timestamps, without which none of this was
measurable.

## Result

Measured on hardware, same unit, after the change:

```
18:12:06  daemon stored the message (counter 18 -> 19)
18:12:07  counter moved -> waking up
18:12:07  fetched 1 new message(s)
18:12:07  delivering to destination
18:12:07  delivered
```

Under a second, down from 27s.

## What I'm confident about, and what I'm not

Confident: the hardcoded 300s is a bug regardless of firmware, and the counter
does move exactly when a message is stored on this device.

Less so:

* **Only tested on `CN_ZTE_MU5250V1.0.0B27` (build 2025-12-25).** I don't know
  whether `sms_received_flag` exists or behaves the same on other builds. If
  `uci get` fails, `read_received_counter()` returns `None` and both loops fall
  back to exactly the previous behaviour — so it should be a no-op where the key
  is missing, but that path is untested.
* **The counter increments per SMS *part*** — a 7-part message advances it by 7.
  Irrelevant for "did something arrive", but don't read it as a message count.
* **Its absolute value is not stable.** I saw it read 27, then 15 later, so
  something resets it. Only the *change* is used, so a reset causes at most one
  spurious wake-up and a wasted list query.

Worth noting the underlying oddity in case it's news: on this firmware the event
is emitted *never*, though the daemon clearly knows about the message — it
stores it and, with the firmware's own forwarding enabled, relays it instantly.
`zwrt_wms_status_event` does exist in the binary. I couldn't determine why it
never fires; details in the issue I'm filing alongside this.

---

**Disclosure:** this patch was written by an AI assistant (Claude) working on my
device. The measurements above are real and were taken on hardware, but I don't
read Rust and haven't reviewed the code line by line — please review accordingly.
